### PR TITLE
Implemented async, messaging based handling of analytics events

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,8 @@ jobs:
 
   e2e-frontend:
     name: E2E Tests (Frontend)
+    # TEMPORARILY DISABLED until 2026-05-01 — see https://github.com/christopherhouse/APIC-Vibe-Portal/issues/227
+    if: false
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,6 +66,14 @@ jobs:
         working-directory: src/governance-worker
         run: uv run ruff format --check .
 
+      - name: Lint Analytics Processor
+        working-directory: src/analytics-processor
+        run: uv run ruff check .
+
+      - name: Check Analytics Processor formatting
+        working-directory: src/analytics-processor
+        run: uv run ruff format --check .
+
   typecheck:
     name: TypeScript Type Check
     runs-on: ubuntu-latest
@@ -305,4 +313,50 @@ jobs:
 
       - name: Validate Governance Worker
         working-directory: src/governance-worker
+        run: uv run python -m compileall .
+
+  test-analytics-processor:
+    name: Test Analytics Processor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install UV
+        run: pip install uv
+
+      - name: Install dependencies
+        working-directory: src/analytics-processor
+        run: uv sync
+
+      - name: Run Analytics Processor tests
+        working-directory: src/analytics-processor
+        run: uv run pytest
+
+  build-analytics-processor:
+    name: Build Analytics Processor
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Setup Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: '3.13'
+
+      - name: Install UV
+        run: pip install uv
+
+      - name: Install dependencies
+        working-directory: src/analytics-processor
+        run: uv sync
+
+      - name: Validate Analytics Processor
+        working-directory: src/analytics-processor
         run: uv run python -m compileall .

--- a/.github/workflows/deploy-app.yml
+++ b/.github/workflows/deploy-app.yml
@@ -63,6 +63,8 @@ jobs:
             dockerfile: ./src/indexer/Dockerfile
           - component: governance-worker
             dockerfile: ./src/governance-worker/Dockerfile
+          - component: analytics-processor
+            dockerfile: ./src/analytics-processor/Dockerfile
     outputs:
       # All matrix variants produce the same git-ref-based tag, so last-writer is stable.
       image-tag: ${{ steps.meta.outputs.version }}
@@ -132,7 +134,7 @@ jobs:
             --bff-identity-resource-id "${{ needs.infra-dev.outputs.bff-identity-resource-id }}" \
             --bff-identity-client-id "${{ needs.infra-dev.outputs.bff-identity-client-id }}" \
             --redis-host ${{ needs.infra-dev.outputs.redis-host }} \
-            --bff-env-vars "BFF_ENTRA_TENANT_ID=${{ vars.AZURE_TENANT_ID }} BFF_ENTRA_CLIENT_ID=${{ vars.BFF_ENTRA_CLIENT_ID }} BFF_ENTRA_AUDIENCE=${{ vars.BFF_ENTRA_AUDIENCE }} API_CENTER_ENDPOINT=${{ needs.infra-dev.outputs.api-center-endpoint }} AI_SEARCH_ENDPOINT=${{ needs.infra-dev.outputs.ai-search-endpoint }} COSMOS_DB_ENDPOINT=${{ needs.infra-dev.outputs.cosmos-db-endpoint }} COSMOS_DB_DATABASE_NAME=${{ needs.infra-dev.outputs.cosmos-db-database-name }} OPENAI_ENDPOINT=${{ needs.infra-dev.outputs.foundry-endpoint }} FOUNDRY_PROJECT_ENDPOINT=${{ needs.infra-dev.outputs.foundry-endpoint }} APPLICATIONINSIGHTS_CONNECTION_STRING=${{ needs.infra-dev.outputs.appinsights-connection-string }}" \
+            --bff-env-vars "BFF_ENTRA_TENANT_ID=${{ vars.AZURE_TENANT_ID }} BFF_ENTRA_CLIENT_ID=${{ vars.BFF_ENTRA_CLIENT_ID }} BFF_ENTRA_AUDIENCE=${{ vars.BFF_ENTRA_AUDIENCE }} API_CENTER_ENDPOINT=${{ needs.infra-dev.outputs.api-center-endpoint }} AI_SEARCH_ENDPOINT=${{ needs.infra-dev.outputs.ai-search-endpoint }} COSMOS_DB_ENDPOINT=${{ needs.infra-dev.outputs.cosmos-db-endpoint }} COSMOS_DB_DATABASE_NAME=${{ needs.infra-dev.outputs.cosmos-db-database-name }} OPENAI_ENDPOINT=${{ needs.infra-dev.outputs.foundry-endpoint }} FOUNDRY_PROJECT_ENDPOINT=${{ needs.infra-dev.outputs.foundry-endpoint }} APPLICATIONINSIGHTS_CONNECTION_STRING=${{ needs.infra-dev.outputs.appinsights-connection-string }} SERVICE_BUS_NAMESPACE=${{ needs.infra-dev.outputs.service-bus-fqns }}" \
             --frontend-env-vars "MSAL_CLIENT_ID=${{ vars.MSAL_CLIENT_ID }} MSAL_AUTHORITY=https://login.microsoftonline.com/${{ vars.AZURE_TENANT_ID }} MSAL_REDIRECT_URI=${{ vars.MSAL_REDIRECT_URI }} BFF_API_SCOPE=${{ vars.BFF_API_SCOPE }} APPLICATIONINSIGHTS_CONNECTION_STRING=${{ needs.infra-dev.outputs.appinsights-connection-string }}" \
             --frontend-image-tag ${{ needs.build-containers.outputs.image-tag }} \
             --bff-image-tag ${{ needs.build-containers.outputs.image-tag }} \
@@ -144,6 +146,25 @@ jobs:
             --governance-identity-resource-id "${{ needs.infra-dev.outputs.governance-identity-resource-id }}" \
             --governance-identity-client-id "${{ needs.infra-dev.outputs.governance-identity-client-id }}" \
             --governance-env-vars "API_CENTER_ENDPOINT=${{ needs.infra-dev.outputs.api-center-endpoint }} COSMOS_DB_ENDPOINT=${{ needs.infra-dev.outputs.cosmos-db-endpoint }} COSMOS_DB_DATABASE_NAME=${{ needs.infra-dev.outputs.cosmos-db-database-name }} APPLICATIONINSIGHTS_CONNECTION_STRING=${{ needs.infra-dev.outputs.appinsights-connection-string }}"
+
+      - name: Deploy Analytics Processor (Bicep)
+        run: |
+          az deployment group create \
+            --name deploy-analytics-processor-dev-${{ github.run_id }} \
+            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
+            --template-file infra/modules/analytics-processor.bicep \
+            --parameters \
+              containerAppName="${{ needs.infra-dev.outputs.analytics-processor-app }}" \
+              containerAppsEnvironmentId="${{ needs.infra-dev.outputs.container-apps-env }}" \
+              acrLoginServer="${{ needs.infra-dev.outputs.acr-login-server }}" \
+              imageTag="${{ needs.build-containers.outputs.image-tag }}" \
+              managedIdentityResourceId="${{ needs.infra-dev.outputs.analytics-processor-identity-resource-id }}" \
+              managedIdentityClientId="${{ needs.infra-dev.outputs.analytics-processor-identity-client-id }}" \
+              storageAccountName="${{ needs.infra-dev.outputs.function-storage-name }}" \
+              appInsightsConnectionString="${{ needs.infra-dev.outputs.appinsights-connection-string }}" \
+              serviceBusNamespace="${{ needs.infra-dev.outputs.service-bus-fqns }}" \
+              cosmosDbEndpoint="${{ needs.infra-dev.outputs.cosmos-db-endpoint }}" \
+              tags='{"Environment":"dev","Application":"APIC-Vibe-Portal","ManagedBy":"Bicep","SecurityControl":"Ignore"}'
 
   deploy-staging:
     name: Deploy to Staging
@@ -176,7 +197,7 @@ jobs:
             --bff-identity-resource-id "${{ needs.infra-staging.outputs.bff-identity-resource-id }}" \
             --bff-identity-client-id "${{ needs.infra-staging.outputs.bff-identity-client-id }}" \
             --redis-host ${{ needs.infra-staging.outputs.redis-host }} \
-            --bff-env-vars "BFF_ENTRA_TENANT_ID=${{ vars.AZURE_TENANT_ID }} BFF_ENTRA_CLIENT_ID=${{ vars.BFF_ENTRA_CLIENT_ID }} BFF_ENTRA_AUDIENCE=${{ vars.BFF_ENTRA_AUDIENCE }} API_CENTER_ENDPOINT=${{ needs.infra-staging.outputs.api-center-endpoint }} AI_SEARCH_ENDPOINT=${{ needs.infra-staging.outputs.ai-search-endpoint }} COSMOS_DB_ENDPOINT=${{ needs.infra-staging.outputs.cosmos-db-endpoint }} COSMOS_DB_DATABASE_NAME=${{ needs.infra-staging.outputs.cosmos-db-database-name }} OPENAI_ENDPOINT=${{ needs.infra-staging.outputs.foundry-endpoint }} FOUNDRY_PROJECT_ENDPOINT=${{ needs.infra-staging.outputs.foundry-endpoint }} APPLICATIONINSIGHTS_CONNECTION_STRING=${{ needs.infra-staging.outputs.appinsights-connection-string }}" \
+            --bff-env-vars "BFF_ENTRA_TENANT_ID=${{ vars.AZURE_TENANT_ID }} BFF_ENTRA_CLIENT_ID=${{ vars.BFF_ENTRA_CLIENT_ID }} BFF_ENTRA_AUDIENCE=${{ vars.BFF_ENTRA_AUDIENCE }} API_CENTER_ENDPOINT=${{ needs.infra-staging.outputs.api-center-endpoint }} AI_SEARCH_ENDPOINT=${{ needs.infra-staging.outputs.ai-search-endpoint }} COSMOS_DB_ENDPOINT=${{ needs.infra-staging.outputs.cosmos-db-endpoint }} COSMOS_DB_DATABASE_NAME=${{ needs.infra-staging.outputs.cosmos-db-database-name }} OPENAI_ENDPOINT=${{ needs.infra-staging.outputs.foundry-endpoint }} FOUNDRY_PROJECT_ENDPOINT=${{ needs.infra-staging.outputs.foundry-endpoint }} APPLICATIONINSIGHTS_CONNECTION_STRING=${{ needs.infra-staging.outputs.appinsights-connection-string }} SERVICE_BUS_NAMESPACE=${{ needs.infra-staging.outputs.service-bus-fqns }}" \
             --frontend-env-vars "MSAL_CLIENT_ID=${{ vars.MSAL_CLIENT_ID }} MSAL_AUTHORITY=https://login.microsoftonline.com/${{ vars.AZURE_TENANT_ID }} MSAL_REDIRECT_URI=${{ vars.MSAL_REDIRECT_URI }} BFF_API_SCOPE=${{ vars.BFF_API_SCOPE }} APPLICATIONINSIGHTS_CONNECTION_STRING=${{ needs.infra-staging.outputs.appinsights-connection-string }}" \
             --frontend-image-tag ${{ needs.build-containers.outputs.image-tag }} \
             --bff-image-tag ${{ needs.build-containers.outputs.image-tag }} \
@@ -188,6 +209,25 @@ jobs:
             --governance-identity-resource-id "${{ needs.infra-staging.outputs.governance-identity-resource-id }}" \
             --governance-identity-client-id "${{ needs.infra-staging.outputs.governance-identity-client-id }}" \
             --governance-env-vars "API_CENTER_ENDPOINT=${{ needs.infra-staging.outputs.api-center-endpoint }} COSMOS_DB_ENDPOINT=${{ needs.infra-staging.outputs.cosmos-db-endpoint }} COSMOS_DB_DATABASE_NAME=${{ needs.infra-staging.outputs.cosmos-db-database-name }} APPLICATIONINSIGHTS_CONNECTION_STRING=${{ needs.infra-staging.outputs.appinsights-connection-string }}"
+
+      - name: Deploy Analytics Processor (Bicep)
+        run: |
+          az deployment group create \
+            --name deploy-analytics-processor-staging-${{ github.run_id }} \
+            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
+            --template-file infra/modules/analytics-processor.bicep \
+            --parameters \
+              containerAppName="${{ needs.infra-staging.outputs.analytics-processor-app }}" \
+              containerAppsEnvironmentId="${{ needs.infra-staging.outputs.container-apps-env }}" \
+              acrLoginServer="${{ needs.infra-dev.outputs.acr-login-server }}" \
+              imageTag="${{ needs.build-containers.outputs.image-tag }}" \
+              managedIdentityResourceId="${{ needs.infra-staging.outputs.analytics-processor-identity-resource-id }}" \
+              managedIdentityClientId="${{ needs.infra-staging.outputs.analytics-processor-identity-client-id }}" \
+              storageAccountName="${{ needs.infra-staging.outputs.function-storage-name }}" \
+              appInsightsConnectionString="${{ needs.infra-staging.outputs.appinsights-connection-string }}" \
+              serviceBusNamespace="${{ needs.infra-staging.outputs.service-bus-fqns }}" \
+              cosmosDbEndpoint="${{ needs.infra-staging.outputs.cosmos-db-endpoint }}" \
+              tags='{"Environment":"staging","Application":"APIC-Vibe-Portal","ManagedBy":"Bicep","SecurityControl":"Ignore"}'
 
   deploy-prod:
     name: Deploy to Production
@@ -220,7 +260,7 @@ jobs:
             --bff-identity-resource-id "${{ needs.infra-prod.outputs.bff-identity-resource-id }}" \
             --bff-identity-client-id "${{ needs.infra-prod.outputs.bff-identity-client-id }}" \
             --redis-host ${{ needs.infra-prod.outputs.redis-host }} \
-            --bff-env-vars "BFF_ENTRA_TENANT_ID=${{ vars.AZURE_TENANT_ID }} BFF_ENTRA_CLIENT_ID=${{ vars.BFF_ENTRA_CLIENT_ID }} BFF_ENTRA_AUDIENCE=${{ vars.BFF_ENTRA_AUDIENCE }} API_CENTER_ENDPOINT=${{ needs.infra-prod.outputs.api-center-endpoint }} AI_SEARCH_ENDPOINT=${{ needs.infra-prod.outputs.ai-search-endpoint }} COSMOS_DB_ENDPOINT=${{ needs.infra-prod.outputs.cosmos-db-endpoint }} COSMOS_DB_DATABASE_NAME=${{ needs.infra-prod.outputs.cosmos-db-database-name }} OPENAI_ENDPOINT=${{ needs.infra-prod.outputs.foundry-endpoint }} FOUNDRY_PROJECT_ENDPOINT=${{ needs.infra-prod.outputs.foundry-endpoint }} APPLICATIONINSIGHTS_CONNECTION_STRING=${{ needs.infra-prod.outputs.appinsights-connection-string }}" \
+            --bff-env-vars "BFF_ENTRA_TENANT_ID=${{ vars.AZURE_TENANT_ID }} BFF_ENTRA_CLIENT_ID=${{ vars.BFF_ENTRA_CLIENT_ID }} BFF_ENTRA_AUDIENCE=${{ vars.BFF_ENTRA_AUDIENCE }} API_CENTER_ENDPOINT=${{ needs.infra-prod.outputs.api-center-endpoint }} AI_SEARCH_ENDPOINT=${{ needs.infra-prod.outputs.ai-search-endpoint }} COSMOS_DB_ENDPOINT=${{ needs.infra-prod.outputs.cosmos-db-endpoint }} COSMOS_DB_DATABASE_NAME=${{ needs.infra-prod.outputs.cosmos-db-database-name }} OPENAI_ENDPOINT=${{ needs.infra-prod.outputs.foundry-endpoint }} FOUNDRY_PROJECT_ENDPOINT=${{ needs.infra-prod.outputs.foundry-endpoint }} APPLICATIONINSIGHTS_CONNECTION_STRING=${{ needs.infra-prod.outputs.appinsights-connection-string }} SERVICE_BUS_NAMESPACE=${{ needs.infra-prod.outputs.service-bus-fqns }}" \
             --frontend-env-vars "MSAL_CLIENT_ID=${{ vars.MSAL_CLIENT_ID }} MSAL_AUTHORITY=https://login.microsoftonline.com/${{ vars.AZURE_TENANT_ID }} MSAL_REDIRECT_URI=${{ vars.MSAL_REDIRECT_URI }} BFF_API_SCOPE=${{ vars.BFF_API_SCOPE }} APPLICATIONINSIGHTS_CONNECTION_STRING=${{ needs.infra-prod.outputs.appinsights-connection-string }}" \
             --frontend-image-tag ${{ needs.build-containers.outputs.image-tag }} \
             --bff-image-tag ${{ needs.build-containers.outputs.image-tag }} \
@@ -232,3 +272,22 @@ jobs:
             --governance-identity-resource-id "${{ needs.infra-prod.outputs.governance-identity-resource-id }}" \
             --governance-identity-client-id "${{ needs.infra-prod.outputs.governance-identity-client-id }}" \
             --governance-env-vars "API_CENTER_ENDPOINT=${{ needs.infra-prod.outputs.api-center-endpoint }} COSMOS_DB_ENDPOINT=${{ needs.infra-prod.outputs.cosmos-db-endpoint }} COSMOS_DB_DATABASE_NAME=${{ needs.infra-prod.outputs.cosmos-db-database-name }} APPLICATIONINSIGHTS_CONNECTION_STRING=${{ needs.infra-prod.outputs.appinsights-connection-string }}"
+
+      - name: Deploy Analytics Processor (Bicep)
+        run: |
+          az deployment group create \
+            --name deploy-analytics-processor-prod-${{ github.run_id }} \
+            --resource-group "${{ vars.AZURE_RESOURCE_GROUP }}" \
+            --template-file infra/modules/analytics-processor.bicep \
+            --parameters \
+              containerAppName="${{ needs.infra-prod.outputs.analytics-processor-app }}" \
+              containerAppsEnvironmentId="${{ needs.infra-prod.outputs.container-apps-env }}" \
+              acrLoginServer="${{ needs.infra-dev.outputs.acr-login-server }}" \
+              imageTag="${{ needs.build-containers.outputs.image-tag }}" \
+              managedIdentityResourceId="${{ needs.infra-prod.outputs.analytics-processor-identity-resource-id }}" \
+              managedIdentityClientId="${{ needs.infra-prod.outputs.analytics-processor-identity-client-id }}" \
+              storageAccountName="${{ needs.infra-prod.outputs.function-storage-name }}" \
+              appInsightsConnectionString="${{ needs.infra-prod.outputs.appinsights-connection-string }}" \
+              serviceBusNamespace="${{ needs.infra-prod.outputs.service-bus-fqns }}" \
+              cosmosDbEndpoint="${{ needs.infra-prod.outputs.cosmos-db-endpoint }}" \
+              tags='{"Environment":"prod","Application":"APIC-Vibe-Portal","ManagedBy":"Bicep","SecurityControl":"Ignore"}'

--- a/.github/workflows/deploy-infra.yml
+++ b/.github/workflows/deploy-infra.yml
@@ -84,6 +84,21 @@ on:
       governance-identity-client-id:
         description: 'Governance worker managed identity client ID'
         value: ${{ jobs.deploy.outputs.governance-identity-client-id }}
+      service-bus-fqns:
+        description: 'Service Bus fully qualified namespace'
+        value: ${{ jobs.deploy.outputs.service-bus-fqns }}
+      analytics-processor-app:
+        description: 'Analytics processor Container App name'
+        value: ${{ jobs.deploy.outputs.analytics-processor-app }}
+      analytics-processor-identity-resource-id:
+        description: 'Analytics processor managed identity resource ID'
+        value: ${{ jobs.deploy.outputs.analytics-processor-identity-resource-id }}
+      analytics-processor-identity-client-id:
+        description: 'Analytics processor managed identity client ID'
+        value: ${{ jobs.deploy.outputs.analytics-processor-identity-client-id }}
+      function-storage-name:
+        description: 'Function storage account name'
+        value: ${{ jobs.deploy.outputs.function-storage-name }}
 
 permissions:
   id-token: write
@@ -146,6 +161,11 @@ jobs:
       indexer-identity-client-id: ${{ steps.outputs.outputs.indexer-identity-client-id }}
       governance-identity-resource-id: ${{ steps.outputs.outputs.governance-identity-resource-id }}
       governance-identity-client-id: ${{ steps.outputs.outputs.governance-identity-client-id }}
+      service-bus-fqns: ${{ steps.outputs.outputs.service-bus-fqns }}
+      analytics-processor-app: ${{ steps.outputs.outputs.analytics-processor-app }}
+      analytics-processor-identity-resource-id: ${{ steps.outputs.outputs.analytics-processor-identity-resource-id }}
+      analytics-processor-identity-client-id: ${{ steps.outputs.outputs.analytics-processor-identity-client-id }}
+      function-storage-name: ${{ steps.outputs.outputs.function-storage-name }}
     steps:
       - name: Checkout code
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
@@ -189,3 +209,8 @@ jobs:
           echo "indexer-identity-client-id=$(echo $RESULT | jq -r '.indexerIdentityClientId.value')" >> $GITHUB_OUTPUT
           echo "governance-identity-resource-id=$(echo $RESULT | jq -r '.governanceIdentityResourceId.value')" >> $GITHUB_OUTPUT
           echo "governance-identity-client-id=$(echo $RESULT | jq -r '.governanceIdentityClientId.value')" >> $GITHUB_OUTPUT
+          echo "service-bus-fqns=$(echo $RESULT | jq -r '.serviceBusFullyQualifiedNamespace.value')" >> $GITHUB_OUTPUT
+          echo "analytics-processor-app=$(echo $RESULT | jq -r '.analyticsProcessorAppName.value')" >> $GITHUB_OUTPUT
+          echo "analytics-processor-identity-resource-id=$(echo $RESULT | jq -r '.analyticsProcessorIdentityResourceId.value')" >> $GITHUB_OUTPUT
+          echo "analytics-processor-identity-client-id=$(echo $RESULT | jq -r '.analyticsProcessorIdentityClientId.value')" >> $GITHUB_OUTPUT
+          echo "function-storage-name=$(echo $RESULT | jq -r '.functionStorageAccountName.value')" >> $GITHUB_OUTPUT

--- a/.github/workflows/load-test.yml
+++ b/.github/workflows/load-test.yml
@@ -27,6 +27,8 @@ permissions:
 jobs:
   load-test:
     name: Run BFF Load Test
+    # TEMPORARILY DISABLED until 2026-05-01 — see https://github.com/christopherhouse/APIC-Vibe-Portal/issues/227
+    if: false
     runs-on: ubuntu-latest
     # Only run if manually dispatched, or if the triggering workflow was a
     # push-based deploy (not a manual staging/prod dispatch) that succeeded.

--- a/infra/main.bicep
+++ b/infra/main.bicep
@@ -97,6 +97,7 @@ var resourceNames = {
   bffIdentity: '${namePrefix}-id-bff-${environmentName}-${uniqueSuffix}'
   indexerIdentity: '${namePrefix}-id-indexer-${environmentName}-${uniqueSuffix}'
   governanceIdentity: '${namePrefix}-id-governance-${environmentName}-${uniqueSuffix}'
+  analyticsProcessorIdentity: '${namePrefix}-id-analytics-${environmentName}-${uniqueSuffix}'
   keyVault: '${kvPrefix}${kvSuffix}' // Max 24 chars: 10 (prefix) + 13 (suffix) = 23
   containerRegistry: '${namePrefix}acr${environmentName}${uniqueSuffix}'
   containerAppsEnv: '${namePrefix}-cae-${environmentName}-${uniqueSuffix}'
@@ -110,6 +111,9 @@ var resourceNames = {
   foundryProject: '${namePrefix}-project-${environmentName}'
   redisCache: '${namePrefix}-redis-${environmentName}-${uniqueSuffix}'
   loadTest: '${namePrefix}-lt-${environmentName}-${uniqueSuffix}'
+  serviceBus: '${namePrefix}-sb-${environmentName}-${uniqueSuffix}'
+  functionStorage: '${namePrefix}fnst${substring(environmentName, 0, 1)}${uniqueSuffix}'
+  analyticsProcessorApp: '${namePrefix}-analytics-${environmentName}'
 }
 
 // ============================================================================
@@ -180,6 +184,16 @@ module governanceIdentity 'modules/managed-identity.bicep' = {
   }
 }
 
+// Analytics Processor Container App identity (AcrPull + SB receive + Cosmos write + Storage)
+module analyticsProcessorIdentity 'modules/managed-identity.bicep' = {
+  name: 'analytics-processor-identity-${deployment().name}'
+  params: {
+    location: location
+    managedIdentityName: resourceNames.analyticsProcessorIdentity
+    tags: tags
+  }
+}
+
 // ============================================================================
 // MODULE 3: Key Vault
 // ============================================================================
@@ -212,6 +226,7 @@ module containerRegistry 'modules/acr.bicep' = {
     bffManagedIdentityPrincipalId: bffIdentity.outputs.principalId
     indexerManagedIdentityPrincipalId: indexerIdentity.outputs.principalId
     governanceManagedIdentityPrincipalId: governanceIdentity.outputs.principalId
+    analyticsProcessorManagedIdentityPrincipalId: analyticsProcessorIdentity.outputs.principalId
     logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
     enablePrivateEndpoint: enablePrivateEndpoints
     privateEndpointSubnetId: privateEndpointSubnetId
@@ -299,6 +314,7 @@ module cosmosDb 'modules/cosmosdb.bicep' = {
     cosmosDbAccountName: resourceNames.cosmosDb
     managedIdentityPrincipalId: bffIdentity.outputs.principalId
     governanceIdentityPrincipalId: governanceIdentity.outputs.principalId
+    analyticsProcessorIdentityPrincipalId: analyticsProcessorIdentity.outputs.principalId
     additionalLocations: cosmosDbLocations
     logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
     enablePrivateEndpoint: enablePrivateEndpoints
@@ -364,6 +380,44 @@ module loadTesting 'modules/load-testing.bicep' = {
     tags: tags
   }
 }
+
+// ============================================================================
+// MODULE 13: Azure Service Bus (analytics event pipeline)
+// ============================================================================
+
+module serviceBus 'modules/service-bus.bicep' = {
+  name: 'service-bus-${deployment().name}'
+  params: {
+    location: location
+    serviceBusNamespaceName: resourceNames.serviceBus
+    senderPrincipalId: bffIdentity.outputs.principalId
+    receiverPrincipalId: analyticsProcessorIdentity.outputs.principalId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
+    enablePrivateEndpoint: enablePrivateEndpoints
+    privateEndpointSubnetId: privateEndpointSubnetId
+    tags: tags
+  }
+}
+
+// ============================================================================
+// MODULE 14: Function App Storage Account (analytics processor host state)
+// ============================================================================
+
+module functionStorage 'modules/function-storage.bicep' = {
+  name: 'function-storage-${deployment().name}'
+  params: {
+    location: location
+    storageAccountName: resourceNames.functionStorage
+    analyticsProcessorPrincipalId: analyticsProcessorIdentity.outputs.principalId
+    logAnalyticsWorkspaceId: monitoring.outputs.logAnalyticsWorkspaceId
+    tags: tags
+  }
+}
+
+// NOTE: Analytics Processor Container App (Module 15) is deployed separately
+// in deploy-app.yml AFTER images are built and pushed to ACR. This avoids a
+// chicken-and-egg problem where the Container App references an ACR image that
+// doesn't exist yet during initial infrastructure provisioning.
 
 // ============================================================================
 // OUTPUTS
@@ -495,3 +549,21 @@ output loadTestName string = loadTesting.outputs.name
 
 @description('Azure Load Testing data-plane endpoint')
 output loadTestDataPlaneUri string = loadTesting.outputs.dataPlaneUri
+
+@description('Function Storage Account Name (for analytics processor AzureWebJobsStorage)')
+output functionStorageAccountName string = functionStorage.outputs.name
+
+@description('Analytics Processor Managed Identity resource ID')
+output analyticsProcessorIdentityResourceId string = analyticsProcessorIdentity.outputs.id
+
+@description('Analytics Processor Managed Identity Client ID')
+output analyticsProcessorIdentityClientId string = analyticsProcessorIdentity.outputs.clientId
+
+@description('Service Bus Fully Qualified Namespace')
+output serviceBusFullyQualifiedNamespace string = serviceBus.outputs.fullyQualifiedNamespace
+
+@description('Service Bus Namespace Name')
+output serviceBusNamespaceName string = serviceBus.outputs.namespaceName
+
+@description('Analytics Processor Container App Name')
+output analyticsProcessorAppName string = resourceNames.analyticsProcessorApp

--- a/infra/modules/acr.bicep
+++ b/infra/modules/acr.bicep
@@ -20,6 +20,9 @@ param indexerManagedIdentityPrincipalId string
 @description('Governance Snapshot Container Job Managed Identity Principal ID for AcrPull RBAC')
 param governanceManagedIdentityPrincipalId string
 
+@description('Analytics Processor Managed Identity Principal ID for AcrPull RBAC')
+param analyticsProcessorManagedIdentityPrincipalId string
+
 @description('Log Analytics Workspace ID for diagnostics')
 param logAnalyticsWorkspaceId string
 
@@ -90,6 +93,17 @@ resource acrPullRoleGovernance 'Microsoft.Authorization/roleAssignments@2022-04-
   properties: {
     roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d') // AcrPull
     principalId: governanceManagedIdentityPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// RBAC: Grant analytics processor managed identity "AcrPull" role
+resource acrPullRoleAnalyticsProcessor 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(containerRegistry.id, analyticsProcessorManagedIdentityPrincipalId, 'AcrPull')
+  scope: containerRegistry
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', '7f951dda-4ed3-4680-a7ca-43fe172d538d') // AcrPull
+    principalId: analyticsProcessorManagedIdentityPrincipalId
     principalType: 'ServicePrincipal'
   }
 }

--- a/infra/modules/analytics-processor.bicep
+++ b/infra/modules/analytics-processor.bicep
@@ -1,0 +1,119 @@
+// ============================================================================
+// Analytics Processor Container App Module (kind: functionapp)
+// ============================================================================
+// Deploys the analytics-processor as a native Function App on Container Apps
+// using Microsoft.App/containerApps with kind=functionapp.
+// The Function is triggered by Service Bus messages and writes to Cosmos DB.
+// No HTTP ingress is needed — pure event consumer.
+// ============================================================================
+
+@description('Azure region')
+param location string = resourceGroup().location
+
+@description('Container App name')
+param containerAppName string
+
+@description('Container Apps Environment resource ID')
+param containerAppsEnvironmentId string
+
+@description('ACR login server (e.g. myacr.azurecr.io)')
+param acrLoginServer string
+
+@description('Container image tag (e.g. main or sha-abc123)')
+param imageTag string
+
+@description('Analytics processor UAMI resource ID (full ARM path)')
+param managedIdentityResourceId string
+
+@description('Analytics processor UAMI client ID')
+param managedIdentityClientId string
+
+@description('Function App storage account name (for AzureWebJobsStorage)')
+param storageAccountName string
+
+@description('Application Insights connection string')
+param appInsightsConnectionString string
+
+@description('Service Bus fully qualified namespace (e.g. myns.servicebus.windows.net)')
+param serviceBusNamespace string
+
+@description('Cosmos DB account endpoint')
+param cosmosDbEndpoint string
+
+@description('Resource tags')
+param tags object = {
+  Application: 'APIC-Vibe-Portal'
+  ManagedBy: 'Bicep'
+  SecurityControl: 'Ignore'
+}
+
+// ============================================================================
+// RESOURCES
+// ============================================================================
+
+// This module is deployed standalone from deploy-app.yml AFTER images are
+// built and pushed to ACR — so the image always exists at deploy time.
+var containerImage = '${acrLoginServer}/analytics-processor:${imageTag}'
+
+resource analyticsProcessor 'Microsoft.App/containerApps@2024-03-01' = {
+  name: containerAppName
+  location: location
+  tags: tags
+  kind: 'functionapp'
+  identity: {
+    type: 'UserAssigned'
+    userAssignedIdentities: {
+      '${managedIdentityResourceId}': {}
+    }
+  }
+  properties: {
+    environmentId: containerAppsEnvironmentId
+    configuration: {
+      activeRevisionsMode: 'Single'
+      registries: [
+        {
+          server: acrLoginServer
+          identity: managedIdentityResourceId
+        }
+      ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'analytics-processor'
+          image: containerImage
+          resources: {
+            cpu: json('0.25')
+            memory: '0.5Gi'
+          }
+          env: [
+            { name: 'AzureWebJobsStorage__accountName', value: storageAccountName }
+            { name: 'AzureWebJobsStorage__credential', value: 'managedidentity' }
+            { name: 'AzureWebJobsStorage__clientId', value: managedIdentityClientId }
+            { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appInsightsConnectionString }
+            { name: 'ServiceBusConnection__fullyQualifiedNamespace', value: serviceBusNamespace }
+            { name: 'ServiceBusConnection__clientId', value: managedIdentityClientId }
+            { name: 'CosmosDBConnection__accountEndpoint', value: cosmosDbEndpoint }
+            { name: 'CosmosDBConnection__clientId', value: managedIdentityClientId }
+            { name: 'FUNCTIONS_WORKER_RUNTIME', value: 'python' }
+            { name: 'AZURE_CLIENT_ID', value: managedIdentityClientId }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: 0
+        maxReplicas: 10
+      }
+    }
+  }
+}
+
+// ============================================================================
+// OUTPUTS
+// ============================================================================
+
+@description('Analytics processor Container App resource ID')
+output id string = analyticsProcessor.id
+
+@description('Analytics processor Container App name')
+output name string = analyticsProcessor.name

--- a/infra/modules/cosmosdb.bicep
+++ b/infra/modules/cosmosdb.bicep
@@ -14,6 +14,9 @@ param managedIdentityPrincipalId string
 @description('Governance Snapshot Container Job Managed Identity Principal ID for Cosmos DB RBAC')
 param governanceIdentityPrincipalId string
 
+@description('Analytics Processor Managed Identity Principal ID for Cosmos DB RBAC')
+param analyticsProcessorIdentityPrincipalId string
+
 @description('Additional failover locations (empty for single-region serverless)')
 param additionalLocations array
 
@@ -215,6 +218,17 @@ resource cosmosDbGovernanceJobRole 'Microsoft.DocumentDB/databaseAccounts/sqlRol
   properties: {
     roleDefinitionId: '${cosmosDbAccount.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002' // Built-in Data Contributor
     principalId: governanceIdentityPrincipalId
+    scope: cosmosDbAccount.id
+  }
+}
+
+// RBAC: Grant analytics processor managed identity "Cosmos DB Built-in Data Contributor" role
+resource cosmosDbAnalyticsProcessorRole 'Microsoft.DocumentDB/databaseAccounts/sqlRoleAssignments@2024-12-01-preview' = {
+  name: guid(cosmosDbAccount.id, analyticsProcessorIdentityPrincipalId, 'Cosmos DB Built-in Data Contributor')
+  parent: cosmosDbAccount
+  properties: {
+    roleDefinitionId: '${cosmosDbAccount.id}/sqlRoleDefinitions/00000000-0000-0000-0000-000000000002' // Built-in Data Contributor
+    principalId: analyticsProcessorIdentityPrincipalId
     scope: cosmosDbAccount.id
   }
 }

--- a/infra/modules/function-storage.bicep
+++ b/infra/modules/function-storage.bicep
@@ -1,0 +1,114 @@
+// ============================================================================
+// Function App Storage Account Module (Entra-only, no shared keys)
+// ============================================================================
+// Storage account required by the Azure Functions host runtime for
+// trigger management, logs, and state.  Identity-based connection via
+// AzureWebJobsStorage__accountName + managed identity.
+// ============================================================================
+
+@description('Azure region')
+param location string
+
+@description('Storage account name')
+param storageAccountName string
+
+@description('Analytics processor Managed Identity Principal ID — needs Blob, Queue, and Table RBAC')
+param analyticsProcessorPrincipalId string
+
+@description('Log Analytics Workspace ID for diagnostics')
+param logAnalyticsWorkspaceId string
+
+@description('Resource tags')
+param tags object
+
+// ============================================================================
+// VARIABLES
+// ============================================================================
+
+// Azure built-in role IDs for AzureWebJobsStorage identity-based connection
+var storageBlobDataOwnerRoleId = 'b7e6dc6d-f1e8-4753-8033-0f276bb0955b'
+var storageQueueDataContributorRoleId = '974c5e8b-45b9-4653-ba55-5f855dd0fb88'
+var storageTableDataContributorRoleId = '0a9a7e1f-b9d0-4cc4-a60d-0319b160aaa3'
+
+// ============================================================================
+// RESOURCES
+// ============================================================================
+
+resource storageAccount 'Microsoft.Storage/storageAccounts@2023-05-01' = {
+  name: storageAccountName
+  location: location
+  tags: tags
+  kind: 'StorageV2'
+  sku: {
+    name: 'Standard_LRS'
+  }
+  properties: {
+    allowSharedKeyAccess: false
+    allowBlobPublicAccess: false
+    supportsHttpsTrafficOnly: true
+    minimumTlsVersion: 'TLS1_2'
+    accessTier: 'Hot'
+  }
+}
+
+// RBAC: Storage Blob Data Owner — host coordination, key store, container creation
+resource blobDataOwnerRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, analyticsProcessorPrincipalId, 'StorageBlobDataOwner')
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageBlobDataOwnerRoleId)
+    principalId: analyticsProcessorPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// RBAC: Storage Queue Data Contributor — host internal queue operations
+resource queueDataContributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, analyticsProcessorPrincipalId, 'StorageQueueDataContributor')
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageQueueDataContributorRoleId)
+    principalId: analyticsProcessorPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// RBAC: Storage Table Data Contributor — diagnostic event persistence
+resource tableDataContributorRole 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(storageAccount.id, analyticsProcessorPrincipalId, 'StorageTableDataContributor')
+  scope: storageAccount
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', storageTableDataContributorRoleId)
+    principalId: analyticsProcessorPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Diagnostic settings
+resource diagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'diag-${storageAccountName}'
+  scope: storageAccount
+  properties: {
+    workspaceId: logAnalyticsWorkspaceId
+    metrics: [
+      {
+        category: 'Transaction'
+        enabled: true
+        retentionPolicy: {
+          enabled: false
+          days: 0
+        }
+      }
+    ]
+  }
+}
+
+// ============================================================================
+// OUTPUTS
+// ============================================================================
+
+@description('Storage account resource ID')
+output id string = storageAccount.id
+
+@description('Storage account name')
+output name string = storageAccount.name

--- a/infra/modules/service-bus.bicep
+++ b/infra/modules/service-bus.bicep
@@ -1,0 +1,198 @@
+// ============================================================================
+// Azure Service Bus Module (Standard SKU, Entra-only auth)
+// ============================================================================
+
+@description('Azure region')
+param location string
+
+@description('Service Bus namespace name')
+param serviceBusNamespaceName string
+
+@description('BFF Managed Identity Principal ID — granted Data Sender role')
+param senderPrincipalId string
+
+@description('Analytics processor Managed Identity Principal ID — granted Data Receiver role')
+param receiverPrincipalId string
+
+@description('Log Analytics Workspace ID for diagnostics')
+param logAnalyticsWorkspaceId string
+
+@description('Enable private endpoint')
+param enablePrivateEndpoint bool
+
+@description('Private endpoint subnet ID')
+param privateEndpointSubnetId string
+
+@description('Resource tags')
+param tags object
+
+// ============================================================================
+// VARIABLES
+// ============================================================================
+
+var topicName = 'analytics-events'
+var subscriptionName = 'cosmos-writer'
+
+// Azure built-in role IDs
+var serviceBusDataSenderRoleId = '69a216fc-b8fb-44d8-bc22-1f3c2cd27a39'
+var serviceBusDataReceiverRoleId = '4f6d3b9b-027b-4f4c-9142-0e5a2a2247e0'
+
+// ============================================================================
+// RESOURCES
+// ============================================================================
+
+resource serviceBusNamespace 'Microsoft.ServiceBus/namespaces@2024-01-01' = {
+  name: serviceBusNamespaceName
+  location: location
+  tags: tags
+  sku: {
+    name: 'Standard'
+    tier: 'Standard'
+  }
+  properties: {
+    disableLocalAuth: true
+    publicNetworkAccess: enablePrivateEndpoint ? 'Disabled' : 'Enabled'
+    minimumTlsVersion: '1.2'
+  }
+}
+
+resource topic 'Microsoft.ServiceBus/namespaces/topics@2024-01-01' = {
+  parent: serviceBusNamespace
+  name: topicName
+  properties: {
+    maxSizeInMegabytes: 1024
+    defaultMessageTimeToLive: 'P14D' // 14 days
+  }
+}
+
+resource subscription 'Microsoft.ServiceBus/namespaces/topics/subscriptions@2024-01-01' = {
+  parent: topic
+  name: subscriptionName
+  properties: {
+    maxDeliveryCount: 10
+    lockDuration: 'PT5M'
+    deadLetteringOnMessageExpiration: true
+    defaultMessageTimeToLive: 'P14D'
+  }
+}
+
+// Default "all messages" filter rule (1=1)
+resource filterRule 'Microsoft.ServiceBus/namespaces/topics/subscriptions/rules@2024-01-01' = {
+  parent: subscription
+  name: 'all-messages'
+  properties: {
+    filterType: 'SqlFilter'
+    sqlFilter: {
+      sqlExpression: '1=1'
+    }
+  }
+}
+
+// RBAC: Grant BFF identity "Azure Service Bus Data Sender" role
+resource senderRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(serviceBusNamespace.id, senderPrincipalId, 'ServiceBusDataSender')
+  scope: serviceBusNamespace
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', serviceBusDataSenderRoleId)
+    principalId: senderPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// RBAC: Grant analytics processor identity "Azure Service Bus Data Receiver" role
+resource receiverRoleAssignment 'Microsoft.Authorization/roleAssignments@2022-04-01' = {
+  name: guid(serviceBusNamespace.id, receiverPrincipalId, 'ServiceBusDataReceiver')
+  scope: serviceBusNamespace
+  properties: {
+    roleDefinitionId: subscriptionResourceId('Microsoft.Authorization/roleDefinitions', serviceBusDataReceiverRoleId)
+    principalId: receiverPrincipalId
+    principalType: 'ServicePrincipal'
+  }
+}
+
+// Diagnostic settings
+resource diagnostics 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
+  name: 'diag-${serviceBusNamespaceName}'
+  scope: serviceBusNamespace
+  properties: {
+    workspaceId: logAnalyticsWorkspaceId
+    logs: [
+      {
+        category: 'OperationalLogs'
+        enabled: true
+        retentionPolicy: {
+          enabled: false
+          days: 0
+        }
+      }
+      {
+        category: 'VNetAndIPFilteringLogs'
+        enabled: true
+        retentionPolicy: {
+          enabled: false
+          days: 0
+        }
+      }
+      {
+        category: 'RuntimeAuditLogs'
+        enabled: true
+        retentionPolicy: {
+          enabled: false
+          days: 0
+        }
+      }
+    ]
+    metrics: [
+      {
+        category: 'AllMetrics'
+        enabled: true
+        retentionPolicy: {
+          enabled: false
+          days: 0
+        }
+      }
+    ]
+  }
+}
+
+// Private endpoint (if enabled)
+resource privateEndpoint 'Microsoft.Network/privateEndpoints@2023-11-01' = if (enablePrivateEndpoint) {
+  name: '${serviceBusNamespaceName}-pe'
+  location: location
+  tags: tags
+  properties: {
+    subnet: {
+      id: privateEndpointSubnetId
+    }
+    privateLinkServiceConnections: [
+      {
+        name: '${serviceBusNamespaceName}-pe-connection'
+        properties: {
+          privateLinkServiceId: serviceBusNamespace.id
+          groupIds: [
+            'namespace'
+          ]
+        }
+      }
+    ]
+  }
+}
+
+// ============================================================================
+// OUTPUTS
+// ============================================================================
+
+@description('Service Bus namespace resource ID')
+output id string = serviceBusNamespace.id
+
+@description('Service Bus namespace name')
+output namespaceName string = serviceBusNamespace.name
+
+@description('Service Bus fully qualified namespace (e.g. myns.servicebus.windows.net)')
+output fullyQualifiedNamespace string = '${serviceBusNamespace.name}.servicebus.windows.net'
+
+@description('Service Bus topic name')
+output topicName string = topicName
+
+@description('Service Bus subscription name')
+output subscriptionName string = subscriptionName

--- a/src/analytics-processor/Dockerfile
+++ b/src/analytics-processor/Dockerfile
@@ -45,3 +45,6 @@ COPY --from=builder /home/site/wwwroot/analytics_processor /home/site/wwwroot/an
 
 # Set the virtual environment as the Python path
 ENV PATH="/home/site/wwwroot/.venv/bin:$PATH"
+
+# Run as non-root (the Azure Functions base image provides UID 1000)
+USER 1000

--- a/src/analytics-processor/Dockerfile
+++ b/src/analytics-processor/Dockerfile
@@ -1,0 +1,47 @@
+# ============================================================================
+# Analytics Processor Dockerfile — Azure Functions on Container Apps
+#
+# Build context MUST be src/analytics-processor:
+#   docker build -t analytics-processor src/analytics-processor
+# ============================================================================
+
+# Build stage
+FROM mcr.microsoft.com/azure-functions/python:4-python3.13-slim AS builder
+
+WORKDIR /home/site/wwwroot
+
+# Install UV
+RUN pip install --no-cache-dir uv
+
+# Copy dependency files first (cache layer)
+COPY pyproject.toml ./
+# Install uv.lock if it exists; otherwise generate it
+COPY uv.lock* ./
+RUN uv sync --frozen --no-dev --no-install-project 2>/dev/null || uv sync --no-dev --no-install-project
+
+# Copy source code
+COPY function_app.py host.json ./
+COPY analytics_processor/ analytics_processor/
+
+# Install the project itself
+RUN uv sync --frozen --no-dev 2>/dev/null || uv sync --no-dev
+
+# Compile Python files
+RUN .venv/bin/python -m compileall -b .
+
+# Production stage
+FROM mcr.microsoft.com/azure-functions/python:4-python3.13-slim AS production
+
+ENV AzureWebJobsScriptRoot=/home/site/wwwroot \
+    AzureFunctionsJobHost__Logging__Console__IsEnabled=true
+
+WORKDIR /home/site/wwwroot
+
+# Copy virtual environment and compiled code from builder
+COPY --from=builder /home/site/wwwroot/.venv /home/site/wwwroot/.venv
+COPY --from=builder /home/site/wwwroot/function_app.py /home/site/wwwroot/function_app.py
+COPY --from=builder /home/site/wwwroot/host.json /home/site/wwwroot/host.json
+COPY --from=builder /home/site/wwwroot/analytics_processor /home/site/wwwroot/analytics_processor
+
+# Set the virtual environment as the Python path
+ENV PATH="/home/site/wwwroot/.venv/bin:$PATH"

--- a/src/analytics-processor/function_app.py
+++ b/src/analytics-processor/function_app.py
@@ -1,0 +1,253 @@
+"""Analytics Processor — Service Bus to Cosmos DB event pipeline.
+
+Consumes batches of analytics events from the ``analytics-events`` Service Bus
+topic and writes them to the ``analytics-events`` Cosmos DB container using the
+Cosmos DB output binding.
+
+Enrichment (PII sanitisation, user ID hashing, timestamp, document
+construction) is performed by the BFF before the message is sent to Service
+Bus.  This function validates document structure and sanitises string values as
+a defence-in-depth measure before persisting to Cosmos DB.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import re
+import time
+from datetime import UTC, datetime
+from typing import Any
+
+import azure.functions as func
+
+app = func.FunctionApp()
+
+logger = logging.getLogger(__name__)
+
+_COSMOS_DB_NAME = "apic-vibe-portal"
+_COSMOS_CONTAINER_NAME = "analytics-events"
+
+# ---------------------------------------------------------------------------
+# Validation & sanitisation helpers
+# ---------------------------------------------------------------------------
+
+_ALLOWED_KEYS: frozenset[str] = frozenset(
+    {
+        "id",
+        "eventType",
+        "timestamp",
+        "userId",
+        "apiId",
+        "metadata",
+        "schemaVersion",
+        "isDeleted",
+        "deletedAt",
+        "ttl",
+    }
+)
+
+_REQUIRED_KEYS: frozenset[str] = frozenset({"id", "eventType", "timestamp"})
+
+# Only word characters (letters, digits, underscore)
+_EVENT_TYPE_RE: re.Pattern[str] = re.compile(r"^[a-zA-Z0-9_]+$")
+
+# Control characters excluding common whitespace (tab, newline, carriage-return)
+_CONTROL_CHAR_RE: re.Pattern[str] = re.compile(r"[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]")
+
+_MAX_STRING_LENGTH = 2048
+_MAX_EVENT_TYPE_LENGTH = 100
+_MAX_ID_LENGTH = 255  # Cosmos DB document ID limit
+_MAX_METADATA_KEY_LENGTH = 256
+_MAX_METADATA_DEPTH = 10
+
+
+def _sanitize_string(value: str, max_length: int = _MAX_STRING_LENGTH) -> str:
+    """Strip control characters and enforce a maximum length."""
+    return _CONTROL_CHAR_RE.sub("", value)[:max_length]
+
+
+def _sanitize_metadata(meta: dict[str, Any], *, _depth: int = 0) -> dict[str, Any]:
+    """Recursively sanitise metadata values, capped at ``_MAX_METADATA_DEPTH``."""
+    if _depth >= _MAX_METADATA_DEPTH:
+        return {}
+
+    result: dict[str, Any] = {}
+    for raw_key, value in meta.items():
+        if not isinstance(raw_key, str):
+            continue
+        sanitized_key = _sanitize_string(raw_key, max_length=_MAX_METADATA_KEY_LENGTH)
+        if isinstance(value, str):
+            result[sanitized_key] = _sanitize_string(value)
+        elif isinstance(value, dict):
+            result[sanitized_key] = _sanitize_metadata(value, _depth=_depth + 1)
+        elif isinstance(value, list):
+            result[sanitized_key] = [
+                _sanitize_string(item)
+                if isinstance(item, str)
+                else (_sanitize_metadata(item, _depth=_depth + 1) if isinstance(item, dict) else item)
+                for item in value
+            ]
+        else:
+            result[sanitized_key] = value
+    return result
+
+
+def _is_valid_timestamp(value: str) -> bool:
+    """Return ``True`` if *value* is a parseable ISO-8601 timestamp."""
+    try:
+        dt = datetime.fromisoformat(value)
+        # Reject dates far in the future or before 2020 (basic sanity)
+        if dt.year < 2020 or dt > datetime.now(UTC).replace(year=datetime.now(UTC).year + 2):
+            return False
+    except (ValueError, OverflowError):
+        return False
+    return True
+
+
+def _validate_and_sanitize(doc: Any) -> dict[str, Any] | None:
+    """Validate document structure and sanitise string values.
+
+    Returns the sanitised document ready for Cosmos DB, or ``None`` if the
+    document fails structural validation.
+    """
+    if not isinstance(doc, dict):
+        return None
+
+    # Required keys must be present
+    if not _REQUIRED_KEYS.issubset(doc.keys()):
+        return None
+
+    # ``id`` must be a non-empty string within Cosmos DB's 255-char limit
+    raw_id = doc.get("id")
+    if not isinstance(raw_id, str) or not raw_id or len(raw_id) > _MAX_ID_LENGTH:
+        return None
+
+    # ``timestamp`` must be a non-empty, parseable ISO-8601 string
+    raw_ts = doc.get("timestamp")
+    if not isinstance(raw_ts, str) or not raw_ts or not _is_valid_timestamp(raw_ts):
+        return None
+
+    # ``eventType`` must match the allowed pattern
+    event_type = doc.get("eventType")
+    if (
+        not isinstance(event_type, str)
+        or not _EVENT_TYPE_RE.match(event_type)
+        or len(event_type) > _MAX_EVENT_TYPE_LENGTH
+    ):
+        return None
+
+    # Strip unknown top-level keys
+    sanitized: dict[str, Any] = {k: v for k, v in doc.items() if k in _ALLOWED_KEYS}
+
+    # Sanitise string fields (skip eventType — already validated by regex)
+    for key in ("id", "timestamp", "userId", "apiId", "deletedAt"):
+        if key in sanitized and isinstance(sanitized[key], str):
+            sanitized[key] = _sanitize_string(sanitized[key])
+
+    # Validate / sanitise typed fields
+    if "metadata" in sanitized:
+        if isinstance(sanitized["metadata"], dict):
+            sanitized["metadata"] = _sanitize_metadata(sanitized["metadata"])
+        else:
+            sanitized["metadata"] = {}
+
+    if "schemaVersion" in sanitized and not isinstance(sanitized["schemaVersion"], int):
+        sanitized.pop("schemaVersion")
+
+    if "isDeleted" in sanitized and not isinstance(sanitized["isDeleted"], bool):
+        sanitized.pop("isDeleted")
+
+    if "ttl" in sanitized and not isinstance(sanitized["ttl"], int):
+        sanitized.pop("ttl")
+
+    return sanitized
+
+
+# ---------------------------------------------------------------------------
+# Function trigger
+# ---------------------------------------------------------------------------
+
+# OTel metrics — emitted as custom dimensions in App Insights via structured
+# logging.  Azure Functions host forwards these to the configured
+# APPLICATIONINSIGHTS_CONNECTION_STRING automatically.
+_total_processed = 0
+_total_failed = 0
+
+
+@app.function_name(name="ProcessAnalyticsEvents")
+@app.service_bus_topic_trigger(
+    arg_name="messages",
+    topic_name="analytics-events",
+    subscription_name="cosmos-writer",
+    connection="ServiceBusConnection",
+    is_batched=True,
+)
+@app.cosmos_db_output(
+    arg_name="documents",
+    database_name=_COSMOS_DB_NAME,
+    container_name=_COSMOS_CONTAINER_NAME,
+    connection="CosmosDBConnection",
+    create_if_not_exists=False,
+)
+def process_analytics_events(
+    messages: list[func.ServiceBusMessage],
+    documents: func.Out[list[str]],
+) -> None:
+    """Process a batch of Service Bus messages and write them to Cosmos DB.
+
+    Each message body is expected to be a JSON-serialised Cosmos document
+    produced by the BFF ``AnalyticsService.record_events`` method.  Documents
+    are validated and sanitised before being forwarded to the Cosmos output
+    binding.
+    """
+    global _total_processed, _total_failed  # noqa: PLW0603
+    start_time = time.monotonic()
+    output_docs: list[str] = []
+    failed = 0
+
+    for message in messages:
+        try:
+            body = message.get_body().decode("utf-8")
+            raw = json.loads(body)
+            sanitized = _validate_and_sanitize(raw)
+            if sanitized is None:
+                failed += 1
+                logger.warning(
+                    "analytics.processor.validation_failed",
+                    extra={
+                        "message_id": message.message_id,
+                        "event_type": raw.get("eventType", "<unknown>") if isinstance(raw, dict) else "<non-dict>",
+                        "has_id": isinstance(raw, dict) and bool(raw.get("id")),
+                        "has_timestamp": isinstance(raw, dict) and bool(raw.get("timestamp")),
+                    },
+                )
+                continue
+            output_docs.append(json.dumps(sanitized))
+        except Exception:
+            failed += 1
+            logger.warning(
+                "analytics.processor.message_failed",
+                extra={"message_id": message.message_id},
+                exc_info=True,
+            )
+
+    if output_docs:
+        documents.set(output_docs)
+
+    _total_processed += len(output_docs)
+    _total_failed += failed
+    duration_ms = (time.monotonic() - start_time) * 1000
+
+    logger.info(
+        "analytics.processor.batch_complete",
+        extra={
+            "processed": len(output_docs),
+            "failed": failed,
+            "total": len(messages),
+            "batch_size": len(messages),
+            "duration_ms": round(duration_ms, 2),
+            "cumulative_processed": _total_processed,
+            "cumulative_failed": _total_failed,
+        },
+    )

--- a/src/analytics-processor/host.json
+++ b/src/analytics-processor/host.json
@@ -1,0 +1,23 @@
+{
+  "version": "2.0",
+  "logging": {
+    "applicationInsights": {
+      "samplingSettings": {
+        "isEnabled": true,
+        "excludedTypes": "Request"
+      }
+    }
+  },
+  "extensions": {
+    "serviceBus": {
+      "maxMessageBatchSize": 50,
+      "autoCompleteMessages": true,
+      "maxAutoLockRenewalDurationInMinutes": 5,
+      "prefetchCount": 100
+    }
+  },
+  "extensionBundle": {
+    "id": "Microsoft.Azure.Functions.ExtensionBundle",
+    "version": "[4.*, 5.0.0)"
+  }
+}

--- a/src/analytics-processor/pyproject.toml
+++ b/src/analytics-processor/pyproject.toml
@@ -1,0 +1,48 @@
+[project]
+name = "apic-vibe-portal-analytics-processor"
+version = "0.0.0"
+description = "Azure Function App — Service Bus to Cosmos DB analytics event processor"
+requires-python = ">=3.13"
+dependencies = [
+    "azure-functions>=1.21.0",
+]
+
+[dependency-groups]
+dev = [
+    "ruff>=0.7.0",
+    "pytest>=8.0.0",
+]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[tool.hatch.build.targets.wheel]
+packages = ["analytics_processor"]
+
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+filterwarnings = [
+    "ignore::DeprecationWarning",
+    "ignore::SyntaxWarning",
+]
+
+[tool.ruff]
+line-length = 120
+target-version = "py313"
+
+[tool.ruff.lint]
+select = [
+    "E",   # pycodestyle errors
+    "W",   # pycodestyle warnings
+    "F",   # pyflakes
+    "I",   # isort
+    "B",   # flake8-bugbear
+    "C4",  # flake8-comprehensions
+    "UP",  # pyupgrade
+]
+ignore = []
+
+[tool.ruff.format]
+quote-style = "double"
+indent-style = "space"

--- a/src/analytics-processor/tests/test_process_events.py
+++ b/src/analytics-processor/tests/test_process_events.py
@@ -1,0 +1,317 @@
+"""Unit tests for the analytics processor function."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from function_app import (
+    _sanitize_metadata,
+    _validate_and_sanitize,
+    process_analytics_events,
+)
+
+
+def _make_sb_message(body: dict | str) -> MagicMock:
+    """Create a mock ServiceBusMessage."""
+    msg = MagicMock()
+    if isinstance(body, dict):
+        msg.get_body.return_value = json.dumps(body).encode("utf-8")
+    else:
+        msg.get_body.return_value = body.encode("utf-8")
+    msg.message_id = "test-msg-id"
+    return msg
+
+
+def _make_cosmos_document(**overrides) -> dict:
+    """Return a representative analytics event document."""
+    doc = {
+        "id": "evt-001",
+        "eventType": "page_view",
+        "userId": "hashed-user-id",
+        "apiId": "",
+        "timestamp": "2026-04-24T10:00:00+00:00",
+        "ttl": 31536000,
+        "metadata": {"pagePath": "/catalog"},
+    }
+    doc.update(overrides)
+    return doc
+
+
+class TestProcessAnalyticsEvents:
+    def test_processes_single_message(self) -> None:
+        doc = _make_cosmos_document()
+        messages = [_make_sb_message(doc)]
+        output = MagicMock()
+
+        process_analytics_events(messages, output)
+
+        output.set.assert_called_once()
+        result = output.set.call_args[0][0]
+        assert len(result) == 1
+        assert json.loads(result[0])["id"] == "evt-001"
+
+    def test_processes_batch_of_messages(self) -> None:
+        docs = [{**_make_cosmos_document(), "id": f"evt-{i}"} for i in range(5)]
+        messages = [_make_sb_message(d) for d in docs]
+        output = MagicMock()
+
+        process_analytics_events(messages, output)
+
+        output.set.assert_called_once()
+        result = output.set.call_args[0][0]
+        assert len(result) == 5
+
+    def test_skips_malformed_message_and_continues(self) -> None:
+        good_doc = _make_cosmos_document()
+        messages = [
+            _make_sb_message("not valid json {{{"),
+            _make_sb_message(good_doc),
+        ]
+        output = MagicMock()
+
+        process_analytics_events(messages, output)
+
+        output.set.assert_called_once()
+        result = output.set.call_args[0][0]
+        assert len(result) == 1
+        assert json.loads(result[0])["id"] == "evt-001"
+
+    def test_handles_empty_batch(self) -> None:
+        output = MagicMock()
+        process_analytics_events([], output)
+        output.set.assert_not_called()
+
+    def test_preserves_document_fields(self) -> None:
+        doc = _make_cosmos_document()
+        doc["metadata"] = {"pagePath": "/api/test", "sessionId": "sess-1"}
+        messages = [_make_sb_message(doc)]
+        output = MagicMock()
+
+        process_analytics_events(messages, output)
+
+        result = json.loads(output.set.call_args[0][0][0])
+        assert result["eventType"] == "page_view"
+        assert result["userId"] == "hashed-user-id"
+        assert result["metadata"]["pagePath"] == "/api/test"
+        assert result["ttl"] == 31536000
+
+    def test_all_messages_malformed_produces_no_output(self) -> None:
+        messages = [
+            _make_sb_message("bad1{"),
+            _make_sb_message("{bad2"),
+        ]
+        output = MagicMock()
+
+        process_analytics_events(messages, output)
+
+        output.set.assert_not_called()
+
+    def test_rejects_document_missing_required_fields(self) -> None:
+        doc = {"id": "evt-001", "eventType": "page_view"}  # missing timestamp
+        messages = [_make_sb_message(doc)]
+        output = MagicMock()
+
+        process_analytics_events(messages, output)
+
+        output.set.assert_not_called()
+
+    def test_rejects_invalid_event_type(self) -> None:
+        doc = _make_cosmos_document(eventType="page view; DROP TABLE")
+        messages = [_make_sb_message(doc)]
+        output = MagicMock()
+
+        process_analytics_events(messages, output)
+
+        output.set.assert_not_called()
+
+    def test_strips_unknown_top_level_keys(self) -> None:
+        doc = _make_cosmos_document()
+        doc["injectedField"] = "should-be-removed"
+        doc["__proto__"] = "bad"
+        messages = [_make_sb_message(doc)]
+        output = MagicMock()
+
+        process_analytics_events(messages, output)
+
+        result = json.loads(output.set.call_args[0][0][0])
+        assert "injectedField" not in result
+        assert "__proto__" not in result
+        assert result["id"] == "evt-001"
+
+    def test_strips_control_characters_from_strings(self) -> None:
+        doc = _make_cosmos_document(userId="user\x00id\x07here")
+        messages = [_make_sb_message(doc)]
+        output = MagicMock()
+
+        process_analytics_events(messages, output)
+
+        result = json.loads(output.set.call_args[0][0][0])
+        assert "\x00" not in result["userId"]
+        assert "\x07" not in result["userId"]
+        assert result["userId"] == "useridhere"
+
+    def test_sanitizes_metadata_strings(self) -> None:
+        doc = _make_cosmos_document(metadata={"path": "/ok", "note": "val\x00ue"})
+        messages = [_make_sb_message(doc)]
+        output = MagicMock()
+
+        process_analytics_events(messages, output)
+
+        result = json.loads(output.set.call_args[0][0][0])
+        assert result["metadata"]["path"] == "/ok"
+        assert result["metadata"]["note"] == "value"
+
+    def test_replaces_non_dict_metadata_with_empty_dict(self) -> None:
+        doc = _make_cosmos_document(metadata="not-a-dict")
+        messages = [_make_sb_message(doc)]
+        output = MagicMock()
+
+        process_analytics_events(messages, output)
+
+        result = json.loads(output.set.call_args[0][0][0])
+        assert result["metadata"] == {}
+
+    def test_rejects_empty_id(self) -> None:
+        doc = _make_cosmos_document(id="")
+        messages = [_make_sb_message(doc)]
+        output = MagicMock()
+
+        process_analytics_events(messages, output)
+
+        output.set.assert_not_called()
+
+    def test_drops_invalid_typed_optional_fields(self) -> None:
+        doc = _make_cosmos_document(schemaVersion="not-an-int", isDeleted="yes", ttl="forever")
+        messages = [_make_sb_message(doc)]
+        output = MagicMock()
+
+        process_analytics_events(messages, output)
+
+        result = json.loads(output.set.call_args[0][0][0])
+        assert "schemaVersion" not in result
+        assert "isDeleted" not in result
+        assert "ttl" not in result
+
+
+# ---------------------------------------------------------------------------
+# _validate_and_sanitize unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestValidateAndSanitize:
+    def test_valid_document_passes(self) -> None:
+        doc = _make_cosmos_document()
+        result = _validate_and_sanitize(doc)
+        assert result is not None
+        assert result["id"] == "evt-001"
+        assert result["eventType"] == "page_view"
+
+    def test_returns_none_for_non_dict(self) -> None:
+        assert _validate_and_sanitize("a string") is None
+        assert _validate_and_sanitize(42) is None
+        assert _validate_and_sanitize([]) is None
+
+    def test_returns_none_for_missing_required_keys(self) -> None:
+        assert _validate_and_sanitize({"id": "x", "eventType": "y"}) is None
+        assert _validate_and_sanitize({"id": "x", "timestamp": "t"}) is None
+        assert _validate_and_sanitize({"eventType": "y", "timestamp": "t"}) is None
+
+    def test_rejects_event_type_with_spaces(self) -> None:
+        doc = _make_cosmos_document(eventType="has spaces")
+        assert _validate_and_sanitize(doc) is None
+
+    def test_rejects_event_type_with_special_chars(self) -> None:
+        doc = _make_cosmos_document(eventType="type;DROP")
+        assert _validate_and_sanitize(doc) is None
+
+    def test_rejects_event_type_exceeding_max_length(self) -> None:
+        doc = _make_cosmos_document(eventType="a" * 101)
+        assert _validate_and_sanitize(doc) is None
+
+    def test_accepts_event_type_at_max_length(self) -> None:
+        doc = _make_cosmos_document(eventType="a" * 100)
+        result = _validate_and_sanitize(doc)
+        assert result is not None
+
+    def test_truncates_long_strings(self) -> None:
+        doc = _make_cosmos_document(apiId="x" * 3000)
+        result = _validate_and_sanitize(doc)
+        assert result is not None
+        assert len(result["apiId"]) == 2048
+
+    def test_rejects_id_exceeding_cosmos_limit(self) -> None:
+        doc = _make_cosmos_document(id="x" * 256)
+        assert _validate_and_sanitize(doc) is None
+
+    def test_accepts_id_at_cosmos_limit(self) -> None:
+        doc = _make_cosmos_document(id="x" * 255)
+        result = _validate_and_sanitize(doc)
+        assert result is not None
+        assert result["id"] == "x" * 255
+
+    def test_rejects_invalid_timestamp(self) -> None:
+        doc = _make_cosmos_document(timestamp="not-a-date")
+        assert _validate_and_sanitize(doc) is None
+
+    def test_rejects_timestamp_before_2020(self) -> None:
+        doc = _make_cosmos_document(timestamp="2019-12-31T23:59:59Z")
+        assert _validate_and_sanitize(doc) is None
+
+    def test_accepts_valid_iso_timestamp(self) -> None:
+        doc = _make_cosmos_document(timestamp="2026-04-24T12:00:00Z")
+        result = _validate_and_sanitize(doc)
+        assert result is not None
+
+    def test_accepts_timestamp_with_offset(self) -> None:
+        doc = _make_cosmos_document(timestamp="2026-04-24T12:00:00+05:30")
+        result = _validate_and_sanitize(doc)
+        assert result is not None
+
+
+# ---------------------------------------------------------------------------
+# _sanitize_metadata unit tests
+# ---------------------------------------------------------------------------
+
+
+class TestSanitizeMetadata:
+    def test_sanitizes_dict_nested_inside_list(self) -> None:
+        meta = {"items": [{"name": "ok\x00bad"}]}
+        result = _sanitize_metadata(meta)
+        assert result["items"][0]["name"] == "okbad"
+
+    def test_deeply_nested_dict_in_list_is_sanitized(self) -> None:
+        meta = {"items": [{"inner": {"value": "clean\x07"}}]}
+        result = _sanitize_metadata(meta)
+        assert result["items"][0]["inner"]["value"] == "clean"
+
+    def test_recursion_depth_is_capped(self) -> None:
+        """Deeply nested metadata should be truncated, not stack-overflow."""
+        # Build 15 levels of nesting (exceeds _MAX_METADATA_DEPTH=10)
+        meta: dict = {"leaf": "value"}
+        for i in range(15):
+            meta = {f"level_{i}": meta}
+        result = _sanitize_metadata(meta)
+        # Walk down — at depth 10 the nested dict should become {}
+        node = result
+        for i in range(14, -1, -1):
+            key = f"level_{i}"
+            if key in node:
+                node = node[key]
+            else:
+                break
+        # At some point the nesting should have been cut off (empty dict)
+        assert node == {} or node == {"leaf": "value"}
+
+    def test_recursion_depth_preserves_shallow_nesting(self) -> None:
+        meta = {"a": {"b": {"c": "ok"}}}
+        result = _sanitize_metadata(meta)
+        assert result["a"]["b"]["c"] == "ok"
+
+    def test_list_of_mixed_types(self) -> None:
+        meta = {"items": ["text\x00", {"key": "val"}, 42, True]}
+        result = _sanitize_metadata(meta)
+        assert result["items"][0] == "text"
+        assert result["items"][1] == {"key": "val"}
+        assert result["items"][2] == 42
+        assert result["items"][3] is True

--- a/src/analytics-processor/uv.lock
+++ b/src/analytics-processor/uv.lock
@@ -1,0 +1,188 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[[package]]
+name = "apic-vibe-portal-analytics-processor"
+version = "0.0.0"
+source = { editable = "." }
+dependencies = [
+    { name = "azure-functions" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "pytest" },
+    { name = "ruff" },
+]
+
+[package.metadata]
+requires-dist = [{ name = "azure-functions", specifier = ">=1.21.0" }]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "pytest", specifier = ">=8.0.0" },
+    { name = "ruff", specifier = ">=0.7.0" },
+]
+
+[[package]]
+name = "azure-functions"
+version = "2.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "werkzeug" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a5/49/5af2f12a4ac49c5549a4a943f7b78650c98a41c776f8360ca506db246f91/azure_functions-2.1.0.tar.gz", hash = "sha256:f0d95bf53569ff32a7258a0ea7d727d1a174183c79e8240760d90876b3d32acd", size = 145464, upload-time = "2026-04-13T16:14:49.299Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ef/c8/fc414a7e97c0fbf5d0a448d02f7bbd6787829686b9e4edb902fa9e7da64e/azure_functions-2.1.0-py3-none-any.whl", hash = "sha256:f840457d5eab8fd51c18d8b8bd0939080766a7fbb85a821838545c767b3a5c61", size = 114718, upload-time = "2026-04-13T16:14:48.127Z" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/38/2f/907b9c7bbba283e68f20259574b13d005c121a0fa4c175f9bed27c4597ff/markupsafe-3.0.3-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:e1cf1972137e83c5d4c136c43ced9ac51d0e124706ee1c8aa8532c1287fa8795", size = 11622, upload-time = "2025-09-27T18:36:41.777Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/d9/5f7756922cdd676869eca1c4e3c0cd0df60ed30199ffd775e319089cb3ed/markupsafe-3.0.3-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:116bb52f642a37c115f517494ea5feb03889e04df47eeff5b130b1808ce7c219", size = 12029, upload-time = "2025-09-27T18:36:43.257Z" },
+    { url = "https://files.pythonhosted.org/packages/00/07/575a68c754943058c78f30db02ee03a64b3c638586fba6a6dd56830b30a3/markupsafe-3.0.3-cp313-cp313-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:133a43e73a802c5562be9bbcd03d090aa5a1fe899db609c29e8c8d815c5f6de6", size = 24374, upload-time = "2025-09-27T18:36:44.508Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/21/9b05698b46f218fc0e118e1f8168395c65c8a2c750ae2bab54fc4bd4e0e8/markupsafe-3.0.3-cp313-cp313-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ccfcd093f13f0f0b7fdd0f198b90053bf7b2f02a3927a30e63f3ccc9df56b676", size = 22980, upload-time = "2025-09-27T18:36:45.385Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/71/544260864f893f18b6827315b988c146b559391e6e7e8f7252839b1b846a/markupsafe-3.0.3-cp313-cp313-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:509fa21c6deb7a7a273d629cf5ec029bc209d1a51178615ddf718f5918992ab9", size = 21990, upload-time = "2025-09-27T18:36:46.916Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/28/b50fc2f74d1ad761af2f5dcce7492648b983d00a65b8c0e0cb457c82ebbe/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:a4afe79fb3de0b7097d81da19090f4df4f8d3a2b3adaa8764138aac2e44f3af1", size = 23784, upload-time = "2025-09-27T18:36:47.884Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/76/104b2aa106a208da8b17a2fb72e033a5a9d7073c68f7e508b94916ed47a9/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_riscv64.whl", hash = "sha256:795e7751525cae078558e679d646ae45574b47ed6e7771863fcc079a6171a0fc", size = 21588, upload-time = "2025-09-27T18:36:48.82Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/99/16a5eb2d140087ebd97180d95249b00a03aa87e29cc224056274f2e45fd6/markupsafe-3.0.3-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:8485f406a96febb5140bfeca44a73e3ce5116b2501ac54fe953e488fb1d03b12", size = 23041, upload-time = "2025-09-27T18:36:49.797Z" },
+    { url = "https://files.pythonhosted.org/packages/19/bc/e7140ed90c5d61d77cea142eed9f9c303f4c4806f60a1044c13e3f1471d0/markupsafe-3.0.3-cp313-cp313-win32.whl", hash = "sha256:bdd37121970bfd8be76c5fb069c7751683bdf373db1ed6c010162b2a130248ed", size = 14543, upload-time = "2025-09-27T18:36:51.584Z" },
+    { url = "https://files.pythonhosted.org/packages/05/73/c4abe620b841b6b791f2edc248f556900667a5a1cf023a6646967ae98335/markupsafe-3.0.3-cp313-cp313-win_amd64.whl", hash = "sha256:9a1abfdc021a164803f4d485104931fb8f8c1efd55bc6b748d2f5774e78b62c5", size = 15113, upload-time = "2025-09-27T18:36:52.537Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/3a/fa34a0f7cfef23cf9500d68cb7c32dd64ffd58a12b09225fb03dd37d5b80/markupsafe-3.0.3-cp313-cp313-win_arm64.whl", hash = "sha256:7e68f88e5b8799aa49c85cd116c932a1ac15caaa3f5db09087854d218359e485", size = 13911, upload-time = "2025-09-27T18:36:53.513Z" },
+    { url = "https://files.pythonhosted.org/packages/e4/d7/e05cd7efe43a88a17a37b3ae96e79a19e846f3f456fe79c57ca61356ef01/markupsafe-3.0.3-cp313-cp313t-macosx_10_13_x86_64.whl", hash = "sha256:218551f6df4868a8d527e3062d0fb968682fe92054e89978594c28e642c43a73", size = 11658, upload-time = "2025-09-27T18:36:54.819Z" },
+    { url = "https://files.pythonhosted.org/packages/99/9e/e412117548182ce2148bdeacdda3bb494260c0b0184360fe0d56389b523b/markupsafe-3.0.3-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:3524b778fe5cfb3452a09d31e7b5adefeea8c5be1d43c4f810ba09f2ceb29d37", size = 12066, upload-time = "2025-09-27T18:36:55.714Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/e6/fa0ffcda717ef64a5108eaa7b4f5ed28d56122c9a6d70ab8b72f9f715c80/markupsafe-3.0.3-cp313-cp313t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:4e885a3d1efa2eadc93c894a21770e4bc67899e3543680313b09f139e149ab19", size = 25639, upload-time = "2025-09-27T18:36:56.908Z" },
+    { url = "https://files.pythonhosted.org/packages/96/ec/2102e881fe9d25fc16cb4b25d5f5cde50970967ffa5dddafdb771237062d/markupsafe-3.0.3-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:8709b08f4a89aa7586de0aadc8da56180242ee0ada3999749b183aa23df95025", size = 23569, upload-time = "2025-09-27T18:36:57.913Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/30/6f2fce1f1f205fc9323255b216ca8a235b15860c34b6798f810f05828e32/markupsafe-3.0.3-cp313-cp313t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:b8512a91625c9b3da6f127803b166b629725e68af71f8184ae7e7d54686a56d6", size = 23284, upload-time = "2025-09-27T18:36:58.833Z" },
+    { url = "https://files.pythonhosted.org/packages/58/47/4a0ccea4ab9f5dcb6f79c0236d954acb382202721e704223a8aafa38b5c8/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:9b79b7a16f7fedff2495d684f2b59b0457c3b493778c9eed31111be64d58279f", size = 24801, upload-time = "2025-09-27T18:36:59.739Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/70/3780e9b72180b6fecb83a4814d84c3bf4b4ae4bf0b19c27196104149734c/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_riscv64.whl", hash = "sha256:12c63dfb4a98206f045aa9563db46507995f7ef6d83b2f68eda65c307c6829eb", size = 22769, upload-time = "2025-09-27T18:37:00.719Z" },
+    { url = "https://files.pythonhosted.org/packages/98/c5/c03c7f4125180fc215220c035beac6b9cb684bc7a067c84fc69414d315f5/markupsafe-3.0.3-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:8f71bc33915be5186016f675cd83a1e08523649b0e33efdb898db577ef5bb009", size = 23642, upload-time = "2025-09-27T18:37:01.673Z" },
+    { url = "https://files.pythonhosted.org/packages/80/d6/2d1b89f6ca4bff1036499b1e29a1d02d282259f3681540e16563f27ebc23/markupsafe-3.0.3-cp313-cp313t-win32.whl", hash = "sha256:69c0b73548bc525c8cb9a251cddf1931d1db4d2258e9599c28c07ef3580ef354", size = 14612, upload-time = "2025-09-27T18:37:02.639Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/98/e48a4bfba0a0ffcf9925fe2d69240bfaa19c6f7507b8cd09c70684a53c1e/markupsafe-3.0.3-cp313-cp313t-win_amd64.whl", hash = "sha256:1b4b79e8ebf6b55351f0d91fe80f893b4743f104bff22e90697db1590e47a218", size = 15200, upload-time = "2025-09-27T18:37:03.582Z" },
+    { url = "https://files.pythonhosted.org/packages/0e/72/e3cc540f351f316e9ed0f092757459afbc595824ca724cbc5a5d4263713f/markupsafe-3.0.3-cp313-cp313t-win_arm64.whl", hash = "sha256:ad2cf8aa28b8c020ab2fc8287b0f823d0a7d8630784c31e9ee5edea20f406287", size = 13973, upload-time = "2025-09-27T18:37:04.929Z" },
+    { url = "https://files.pythonhosted.org/packages/33/8a/8e42d4838cd89b7dde187011e97fe6c3af66d8c044997d2183fbd6d31352/markupsafe-3.0.3-cp314-cp314-macosx_10_13_x86_64.whl", hash = "sha256:eaa9599de571d72e2daf60164784109f19978b327a3910d3e9de8c97b5b70cfe", size = 11619, upload-time = "2025-09-27T18:37:06.342Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/64/7660f8a4a8e53c924d0fa05dc3a55c9cee10bbd82b11c5afb27d44b096ce/markupsafe-3.0.3-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:c47a551199eb8eb2121d4f0f15ae0f923d31350ab9280078d1e5f12b249e0026", size = 12029, upload-time = "2025-09-27T18:37:07.213Z" },
+    { url = "https://files.pythonhosted.org/packages/da/ef/e648bfd021127bef5fa12e1720ffed0c6cbb8310c8d9bea7266337ff06de/markupsafe-3.0.3-cp314-cp314-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f34c41761022dd093b4b6896d4810782ffbabe30f2d443ff5f083e0cbbb8c737", size = 24408, upload-time = "2025-09-27T18:37:09.572Z" },
+    { url = "https://files.pythonhosted.org/packages/41/3c/a36c2450754618e62008bf7435ccb0f88053e07592e6028a34776213d877/markupsafe-3.0.3-cp314-cp314-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:457a69a9577064c05a97c41f4e65148652db078a3a509039e64d3467b9e7ef97", size = 23005, upload-time = "2025-09-27T18:37:10.58Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/20/b7fdf89a8456b099837cd1dc21974632a02a999ec9bf7ca3e490aacd98e7/markupsafe-3.0.3-cp314-cp314-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:e8afc3f2ccfa24215f8cb28dcf43f0113ac3c37c2f0f0806d8c70e4228c5cf4d", size = 22048, upload-time = "2025-09-27T18:37:11.547Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/a7/591f592afdc734f47db08a75793a55d7fbcc6902a723ae4cfbab61010cc5/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_aarch64.whl", hash = "sha256:ec15a59cf5af7be74194f7ab02d0f59a62bdcf1a537677ce67a2537c9b87fcda", size = 23821, upload-time = "2025-09-27T18:37:12.48Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/33/45b24e4f44195b26521bc6f1a82197118f74df348556594bd2262bda1038/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_riscv64.whl", hash = "sha256:0eb9ff8191e8498cca014656ae6b8d61f39da5f95b488805da4bb029cccbfbaf", size = 21606, upload-time = "2025-09-27T18:37:13.485Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/0e/53dfaca23a69fbfbbf17a4b64072090e70717344c52eaaaa9c5ddff1e5f0/markupsafe-3.0.3-cp314-cp314-musllinux_1_2_x86_64.whl", hash = "sha256:2713baf880df847f2bece4230d4d094280f4e67b1e813eec43b4c0e144a34ffe", size = 23043, upload-time = "2025-09-27T18:37:14.408Z" },
+    { url = "https://files.pythonhosted.org/packages/46/11/f333a06fc16236d5238bfe74daccbca41459dcd8d1fa952e8fbd5dccfb70/markupsafe-3.0.3-cp314-cp314-win32.whl", hash = "sha256:729586769a26dbceff69f7a7dbbf59ab6572b99d94576a5592625d5b411576b9", size = 14747, upload-time = "2025-09-27T18:37:15.36Z" },
+    { url = "https://files.pythonhosted.org/packages/28/52/182836104b33b444e400b14f797212f720cbc9ed6ba34c800639d154e821/markupsafe-3.0.3-cp314-cp314-win_amd64.whl", hash = "sha256:bdc919ead48f234740ad807933cdf545180bfbe9342c2bb451556db2ed958581", size = 15341, upload-time = "2025-09-27T18:37:16.496Z" },
+    { url = "https://files.pythonhosted.org/packages/6f/18/acf23e91bd94fd7b3031558b1f013adfa21a8e407a3fdb32745538730382/markupsafe-3.0.3-cp314-cp314-win_arm64.whl", hash = "sha256:5a7d5dc5140555cf21a6fefbdbf8723f06fcd2f63ef108f2854de715e4422cb4", size = 14073, upload-time = "2025-09-27T18:37:17.476Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/f0/57689aa4076e1b43b15fdfa646b04653969d50cf30c32a102762be2485da/markupsafe-3.0.3-cp314-cp314t-macosx_10_13_x86_64.whl", hash = "sha256:1353ef0c1b138e1907ae78e2f6c63ff67501122006b0f9abad68fda5f4ffc6ab", size = 11661, upload-time = "2025-09-27T18:37:18.453Z" },
+    { url = "https://files.pythonhosted.org/packages/89/c3/2e67a7ca217c6912985ec766c6393b636fb0c2344443ff9d91404dc4c79f/markupsafe-3.0.3-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:1085e7fbddd3be5f89cc898938f42c0b3c711fdcb37d75221de2666af647c175", size = 12069, upload-time = "2025-09-27T18:37:19.332Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/00/be561dce4e6ca66b15276e184ce4b8aec61fe83662cce2f7d72bd3249d28/markupsafe-3.0.3-cp314-cp314t-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1b52b4fb9df4eb9ae465f8d0c228a00624de2334f216f178a995ccdcf82c4634", size = 25670, upload-time = "2025-09-27T18:37:20.245Z" },
+    { url = "https://files.pythonhosted.org/packages/50/09/c419f6f5a92e5fadde27efd190eca90f05e1261b10dbd8cbcb39cd8ea1dc/markupsafe-3.0.3-cp314-cp314t-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:fed51ac40f757d41b7c48425901843666a6677e3e8eb0abcff09e4ba6e664f50", size = 23598, upload-time = "2025-09-27T18:37:21.177Z" },
+    { url = "https://files.pythonhosted.org/packages/22/44/a0681611106e0b2921b3033fc19bc53323e0b50bc70cffdd19f7d679bb66/markupsafe-3.0.3-cp314-cp314t-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:f190daf01f13c72eac4efd5c430a8de82489d9cff23c364c3ea822545032993e", size = 23261, upload-time = "2025-09-27T18:37:22.167Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/57/1b0b3f100259dc9fffe780cfb60d4be71375510e435efec3d116b6436d43/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_aarch64.whl", hash = "sha256:e56b7d45a839a697b5eb268c82a71bd8c7f6c94d6fd50c3d577fa39a9f1409f5", size = 24835, upload-time = "2025-09-27T18:37:23.296Z" },
+    { url = "https://files.pythonhosted.org/packages/26/6a/4bf6d0c97c4920f1597cc14dd720705eca0bf7c787aebc6bb4d1bead5388/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_riscv64.whl", hash = "sha256:f3e98bb3798ead92273dc0e5fd0f31ade220f59a266ffd8a4f6065e0a3ce0523", size = 22733, upload-time = "2025-09-27T18:37:24.237Z" },
+    { url = "https://files.pythonhosted.org/packages/14/c7/ca723101509b518797fedc2fdf79ba57f886b4aca8a7d31857ba3ee8281f/markupsafe-3.0.3-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:5678211cb9333a6468fb8d8be0305520aa073f50d17f089b5b4b477ea6e67fdc", size = 23672, upload-time = "2025-09-27T18:37:25.271Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/df/5bd7a48c256faecd1d36edc13133e51397e41b73bb77e1a69deab746ebac/markupsafe-3.0.3-cp314-cp314t-win32.whl", hash = "sha256:915c04ba3851909ce68ccc2b8e2cd691618c4dc4c4232fb7982bca3f41fd8c3d", size = 14819, upload-time = "2025-09-27T18:37:26.285Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/8a/0402ba61a2f16038b48b39bccca271134be00c5c9f0f623208399333c448/markupsafe-3.0.3-cp314-cp314t-win_amd64.whl", hash = "sha256:4faffd047e07c38848ce017e8725090413cd80cbc23d86e55c587bf979e579c9", size = 15426, upload-time = "2025-09-27T18:37:27.316Z" },
+    { url = "https://files.pythonhosted.org/packages/70/bc/6f1c2f612465f5fa89b95bead1f44dcb607670fd42891d8fdcd5d039f4f4/markupsafe-3.0.3-cp314-cp314t-win_arm64.whl", hash = "sha256:32001d6a8fc98c8cb5c947787c5d08b0a50663d139f1305bac5885d98d9b40fa", size = 14146, upload-time = "2025-09-27T18:37:28.327Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.12"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/99/43/3291f1cc9106f4c63bdce7a8d0df5047fe8422a75b091c16b5e9355e0b11/ruff-0.15.12.tar.gz", hash = "sha256:ecea26adb26b4232c0c2ca19ccbc0083a68344180bba2a600605538ce51a40a6", size = 4643852, upload-time = "2026-04-24T18:17:14.305Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/6e/e78ffb61d4686f3d96ba3df2c801161843746dcbcbb17a1e927d4829312b/ruff-0.15.12-py3-none-linux_armv6l.whl", hash = "sha256:f86f176e188e94d6bdbc09f09bfd9dc729059ad93d0e7390b5a73efe19f8861c", size = 10640713, upload-time = "2026-04-24T18:17:22.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/08/a317bc231fb9e7b93e4ef3089501e51922ff88d6936ce5cf870c4fe55419/ruff-0.15.12-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e3bcd123364c3770b8e1b7baaf343cc99a35f197c5c6e8af79015c666c423a6c", size = 11069267, upload-time = "2026-04-24T18:17:30.105Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/a4/f828e9718d3dce1f5f11c39c4f65afd32783c8b2aebb2e3d259e492c47bd/ruff-0.15.12-py3-none-macosx_11_0_arm64.whl", hash = "sha256:fe87510d000220aa1ed530d4448a7c696a0cae1213e5ec30e5874287b66557b5", size = 10397182, upload-time = "2026-04-24T18:17:07.177Z" },
+    { url = "https://files.pythonhosted.org/packages/71/e0/3310fc6d1b5e1fdea22bf3b1b807c7e187b581021b0d7d4514cccdb5fb71/ruff-0.15.12-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:84a1630093121375a3e2a95b4a6dc7b59e2b4ee76216e32d81aae550a832d002", size = 10758012, upload-time = "2026-04-24T18:16:55.759Z" },
+    { url = "https://files.pythonhosted.org/packages/11/c1/a606911aee04c324ddaa883ae418f3569792fd3c4a10c50e0dd0a2311e1e/ruff-0.15.12-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:fb129f40f114f089ebe0ca56c0d251cf2061b17651d464bb6478dc01e69f11f5", size = 10447479, upload-time = "2026-04-24T18:16:51.677Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/68/4201e8444f0894f21ab4aeeaee68aa4f10b51613514a20d80bd628d57e88/ruff-0.15.12-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:b0c862b172d695db7598426b8af465e7e9ac00a3ea2a3630ee67eb82e366aaa6", size = 11234040, upload-time = "2026-04-24T18:17:16.529Z" },
+    { url = "https://files.pythonhosted.org/packages/34/ff/8a6d6cf4ccc23fd67060874e832c18919d1557a0611ebef03fdb01fff11e/ruff-0.15.12-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:2849ea9f3484c3aca43a82f484210370319e7170df4dfe4843395ddf6c57bc33", size = 12087377, upload-time = "2026-04-24T18:17:04.944Z" },
+    { url = "https://files.pythonhosted.org/packages/85/f6/c669cf73f5152f623d34e69866a46d5e6185816b19fcd5b6dd8a2d299922/ruff-0.15.12-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9e77c7e51c07fe396826d5969a5b846d9cd4c402535835fb6e21ce8b28fef847", size = 11367784, upload-time = "2026-04-24T18:17:25.409Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/39/c61d193b8a1daaa8977f7dea9e8d8ba866e02ea7b65d32f6861693aa4c12/ruff-0.15.12-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:83b2f4f2f3b1026b5fb449b467d9264bf22067b600f7b6f41fc5958909f449d0", size = 11344088, upload-time = "2026-04-24T18:17:12.258Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/8d/49afab3645e31e12c590acb6d3b5b69d7aab5b81926dbaf7461f9441f37a/ruff-0.15.12-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:9ba3b8f1afd7e2e43d8943e55f249e13f9682fde09711644a6e7290eb4f3e339", size = 11271770, upload-time = "2026-04-24T18:17:02.457Z" },
+    { url = "https://files.pythonhosted.org/packages/46/06/33f41fe94403e2b755481cdfb9b7ef3e4e0ed031c4581124658d935d52b4/ruff-0.15.12-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:e852ba9fdc890655e1d78f2df1499efbe0e54126bd405362154a75e2bde159c5", size = 10719355, upload-time = "2026-04-24T18:17:27.648Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/59/18aa4e014debbf559670e4048e39260a85c7fcee84acfd761ac01e7b8d35/ruff-0.15.12-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:dd8aed930da53780d22fc70bdf84452c843cf64f8cb4eb38984319c24c5cd5fd", size = 10462758, upload-time = "2026-04-24T18:17:32.347Z" },
+    { url = "https://files.pythonhosted.org/packages/25/e7/cc9f16fd0f3b5fddcbd7ec3d6ae30c8f3fde1047f32a4093a98d633c6570/ruff-0.15.12-py3-none-musllinux_1_2_i686.whl", hash = "sha256:01da3988d225628b709493d7dc67c3b9b12c0210016b08690ef9bd27970b262b", size = 10953498, upload-time = "2026-04-24T18:17:20.674Z" },
+    { url = "https://files.pythonhosted.org/packages/72/7a/a9ba7f98c7a575978698f4230c5e8cc54bbc761af34f560818f933dafa0c/ruff-0.15.12-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:9cae0f92bd5700d1213188b31cd3bdd2b315361296d10b96b8e2337d3d11f53e", size = 11447765, upload-time = "2026-04-24T18:17:09.755Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/f9/0ae446942c846b8266059ad8a30702a35afae55f5cdc54c5adf8d7afdc27/ruff-0.15.12-py3-none-win32.whl", hash = "sha256:d0185894e038d7043ba8fd6aee7499ece6462dc0ea9f1e260c7451807c714c20", size = 10657277, upload-time = "2026-04-24T18:17:18.591Z" },
+    { url = "https://files.pythonhosted.org/packages/33/f1/9614e03e1cdcbf9437570b5400ced8a720b5db22b28d8e0f1bda429f660d/ruff-0.15.12-py3-none-win_amd64.whl", hash = "sha256:c87a162d61ab3adca47c03f7f717c68672edec7d1b5499e652331780fe74950d", size = 11837758, upload-time = "2026-04-24T18:17:00.113Z" },
+    { url = "https://files.pythonhosted.org/packages/c0/98/6beb4b351e472e5f4c4613f7c35a5290b8be2497e183825310c4c3a3984b/ruff-0.15.12-py3-none-win_arm64.whl", hash = "sha256:a538f7a82d061cee7be55542aca1d86d1393d55d81d4fcc314370f4340930d4f", size = 11120821, upload-time = "2026-04-24T18:16:57.979Z" },
+]
+
+[[package]]
+name = "werkzeug"
+version = "3.1.8"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/dd/b2/381be8cfdee792dd117872481b6e378f85c957dd7c5bca38897b08f765fd/werkzeug-3.1.8.tar.gz", hash = "sha256:9bad61a4268dac112f1c5cd4630a56ede601b6ed420300677a869083d70a4c44", size = 875852, upload-time = "2026-04-02T18:49:14.268Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/93/8c/2e650f2afeb7ee576912636c23ddb621c91ac6a98e66dc8d29c3c69446e1/werkzeug-3.1.8-py3-none-any.whl", hash = "sha256:63a77fb8892bf28ebc3178683445222aa500e48ebad5ec77b0ad80f8726b1f50", size = 226459, upload-time = "2026-04-02T18:49:12.72Z" },
+]

--- a/src/bff/apic_vibe_portal_bff/app.py
+++ b/src/bff/apic_vibe_portal_bff/app.py
@@ -23,6 +23,7 @@ from apic_vibe_portal_bff.middleware.request_logger import RequestLoggerMiddlewa
 from apic_vibe_portal_bff.routers import api_catalog, chat, health, search
 from apic_vibe_portal_bff.routers.admin_access_policies import router as admin_access_policies_router
 from apic_vibe_portal_bff.routers.admin_agents import router as admin_agents_router
+from apic_vibe_portal_bff.routers.analytics import close_analytics_service
 from apic_vibe_portal_bff.routers.analytics import router as analytics_router
 from apic_vibe_portal_bff.routers.api_catalog import CatalogApiError, catalog_api_error_handler
 from apic_vibe_portal_bff.routers.api_compare import router as compare_router
@@ -72,6 +73,8 @@ async def _lifespan(_app: FastAPI) -> AsyncIterator[None]:
     thread.start()
     logger.info("Startup cache warm thread started")
     yield
+    # --- Shutdown ---
+    close_analytics_service()
 
 
 def create_app() -> FastAPI:

--- a/src/bff/apic_vibe_portal_bff/config/settings.py
+++ b/src/bff/apic_vibe_portal_bff/config/settings.py
@@ -94,6 +94,20 @@ class Settings(BaseSettings):
         description="Cosmos DB container name for API access policies (security trimming)",
     )
 
+    # --- Azure Service Bus -----------------------------------------------
+    service_bus_namespace: str = Field(
+        default="",
+        description=(
+            "Azure Service Bus fully qualified namespace "
+            "(e.g. myns.servicebus.windows.net). When empty, analytics events "
+            "are written directly to Cosmos DB (no Service Bus decoupling)."
+        ),
+    )
+    service_bus_analytics_topic: str = Field(
+        default="analytics-events",
+        description="Service Bus topic name for analytics events",
+    )
+
     # --- Azure AI Foundry Agent Service ---------------------------------
     foundry_project_endpoint: str = Field(
         default="",

--- a/src/bff/apic_vibe_portal_bff/routers/analytics.py
+++ b/src/bff/apic_vibe_portal_bff/routers/analytics.py
@@ -54,6 +54,7 @@ def _range_days(time_range: str) -> int:
 
 # Service singleton — created lazily on first request.
 _service_instance: AnalyticsService | None = None
+_sb_client: object | None = None  # ServiceBusClient (kept for lifecycle cleanup)
 
 logger = logging.getLogger(__name__)
 
@@ -65,15 +66,22 @@ def _get_service() -> AnalyticsService:
     is wired in here so that events are persisted to Cosmos DB in addition to
     being emitted as structured log entries.
 
+    When ``SERVICE_BUS_NAMESPACE`` is configured, a ``ServiceBusSender`` is
+    created for the analytics topic so that events are sent to Service Bus
+    (primary path) instead of writing directly to Cosmos.  The repository is
+    still provided for fallback writes and GET queries.
+
     If ``COSMOS_DB_ENDPOINT`` is not configured or the repository cannot be
     initialized, the service falls back to structured-log-only delivery so
     that analytics event ingestion degrades gracefully rather than returning
     HTTP 500 on every request.
     """
-    global _service_instance  # noqa: PLW0603
+    global _service_instance, _sb_client  # noqa: PLW0603
     if _service_instance is None:
         settings = get_settings()
         analytics_repo = None
+        sb_sender = None
+
         if settings.cosmos_db_endpoint.strip():
             try:
                 from apic_vibe_portal_bff.data.cosmos_client import get_container
@@ -85,8 +93,48 @@ def _get_service() -> AnalyticsService:
                 logger.exception("Failed to initialise analytics repository — events will be logged only")
         else:
             logger.info("COSMOS_DB_ENDPOINT not configured — analytics events will be logged only")
-        _service_instance = AnalyticsService(repository=analytics_repo)
+
+        if settings.service_bus_namespace.strip():
+            try:
+                from azure.identity import DefaultAzureCredential
+                from azure.servicebus import ServiceBusClient
+
+                credential = DefaultAzureCredential()
+                sb_client = ServiceBusClient(
+                    fully_qualified_namespace=settings.service_bus_namespace,
+                    credential=credential,
+                )
+                _sb_client = sb_client  # store for lifecycle cleanup
+                sb_sender = sb_client.get_topic_sender(topic_name=settings.service_bus_analytics_topic)
+                logger.info(
+                    "Service Bus sender initialised for topic '%s'",
+                    settings.service_bus_analytics_topic,
+                )
+            except Exception:  # noqa: BLE001
+                logger.exception(
+                    "Failed to initialise Service Bus sender — events will fall back to direct Cosmos write"
+                )
+        else:
+            logger.info("SERVICE_BUS_NAMESPACE not configured — analytics events will write directly to Cosmos")
+
+        _service_instance = AnalyticsService(repository=analytics_repo, service_bus_sender=sb_sender)
     return _service_instance
+
+
+def close_analytics_service() -> None:
+    """Close the Service Bus client and sender, releasing AMQP connections.
+
+    Called from the FastAPI lifespan shutdown phase.
+    """
+    global _service_instance, _sb_client  # noqa: PLW0603
+    if _sb_client is not None:
+        try:
+            _sb_client.close()  # type: ignore[union-attr]
+        except Exception:  # noqa: BLE001
+            logger.warning("analytics.service_bus.close_failed", exc_info=True)
+        _sb_client = None
+    _service_instance = None
+    logger.info("analytics.service_bus.closed")
 
 
 AnalyticsServiceDep = Annotated[AnalyticsService, Depends(_get_service)]
@@ -175,7 +223,7 @@ async def post_analytics_events(
     - Returns ``202 Accepted`` with the count of accepted events.
     """
     raw_events = [envelope.model_dump() for envelope in body.events]
-    accepted = service.record_events(raw_events, user=user)
+    accepted = await asyncio.to_thread(service.record_events, raw_events, user)
     return AnalyticsEventBatchResponse(accepted=accepted)
 
 

--- a/src/bff/apic_vibe_portal_bff/services/analytics_service.py
+++ b/src/bff/apic_vibe_portal_bff/services/analytics_service.py
@@ -13,6 +13,7 @@ when one is injected at construction time.
 from __future__ import annotations
 
 import hashlib
+import json
 import logging
 import re
 import uuid
@@ -23,6 +24,8 @@ from apic_vibe_portal_bff.data.models.analytics import AnalyticsEventDocument
 from apic_vibe_portal_bff.middleware.auth import AuthenticatedUser
 
 if TYPE_CHECKING:
+    from azure.servicebus import ServiceBusSender
+
     from apic_vibe_portal_bff.data.repositories.analytics_repository import AnalyticsRepository
 
 logger = logging.getLogger(__name__)
@@ -100,19 +103,34 @@ class AnalyticsService:
 
     Analytics events arrive from the frontend as batches.  Each event is
     enriched with server-side context, emitted as a structured log entry
-    captured by the OTel / Application Insights pipeline, and persisted to
-    the ``analytics-events`` Cosmos DB container when a repository is provided.
+    captured by the OTel / Application Insights pipeline, and persisted via
+    one of two paths:
+
+    1. **Service Bus (primary)** — when a ``ServiceBusSender`` is provided,
+       enriched events are batch-sent to the ``analytics-events`` topic.  A
+       downstream Function App consumes them and writes to Cosmos DB.
+    2. **Direct Cosmos DB (fallback)** — if Service Bus is unavailable or
+       not configured, events are written directly to Cosmos via the
+       repository, preserving the pre-decoupling behaviour.
 
     Parameters
     ----------
     repository:
         Optional :class:`~apic_vibe_portal_bff.data.repositories.analytics_repository.AnalyticsRepository`
-        used to persist events to Cosmos DB.  When ``None`` events are only
-        written to the structured log.
+        used to persist events to Cosmos DB (for reads and fallback writes).
+    service_bus_sender:
+        Optional ``ServiceBusSender`` for the analytics-events topic.
+        When provided, ``record_events`` sends enriched documents to
+        Service Bus instead of writing directly to Cosmos.
     """
 
-    def __init__(self, repository: AnalyticsRepository | None = None) -> None:
+    def __init__(
+        self,
+        repository: AnalyticsRepository | None = None,
+        service_bus_sender: ServiceBusSender | None = None,
+    ) -> None:
         self._repository = repository
+        self._service_bus_sender = service_bus_sender
 
     def record_events(
         self,
@@ -144,6 +162,7 @@ class AnalyticsService:
         """
         user_id_hash = hash_user_id(user.oid) if user else None
         recorded = 0
+        enriched_docs: list[dict[str, Any]] = []
 
         for envelope in events:
             try:
@@ -172,31 +191,76 @@ class AnalyticsService:
 
                 logger.info("analytics.event", extra=extra)
 
-                # Persist to Cosmos DB when a repository is wired in.
-                if self._repository is not None:
-                    api_id = str(event_payload.get("apiId", ""))
-                    # Build metadata: sanitized payload minus fields promoted to
-                    # top-level document fields (type, apiId), plus context fields.
-                    cosmos_metadata: dict[str, Any] = {k: v for k, v in sanitized.items() if k != "apiId"}
-                    if page_path:
-                        cosmos_metadata["pagePath"] = page_path
-                    if session_id is not None:
-                        cosmos_metadata["sessionId"] = session_id
-                    doc = AnalyticsEventDocument.new(
-                        event_id=str(uuid.uuid4()),
-                        event_type=event_type,
-                        user_id=user_id_hash or "",
-                        api_id=api_id,
-                        metadata=cosmos_metadata,
-                    )
-                    self._repository.create(doc.to_cosmos_dict())
-
+                # Build the Cosmos document for persistence (SB or direct).
+                api_id = str(event_payload.get("apiId", ""))
+                cosmos_metadata: dict[str, Any] = {k: v for k, v in sanitized.items() if k != "apiId"}
+                if page_path:
+                    cosmos_metadata["pagePath"] = page_path
+                if session_id is not None:
+                    cosmos_metadata["sessionId"] = session_id
+                doc = AnalyticsEventDocument.new(
+                    event_id=str(uuid.uuid4()),
+                    event_type=event_type,
+                    user_id=user_id_hash or "",
+                    api_id=api_id,
+                    metadata=cosmos_metadata,
+                )
+                enriched_docs.append(doc.to_cosmos_dict())
                 recorded += 1
 
             except Exception:  # noqa: BLE001
                 logger.warning("analytics.event.record_failed", exc_info=True)
 
+        # --- Persist enriched documents ---
+        if enriched_docs:
+            self._persist_events(enriched_docs)
+
         return recorded
+
+    def _persist_events(self, docs: list[dict[str, Any]]) -> None:
+        """Send documents to Service Bus (primary) or Cosmos DB (fallback)."""
+        if self._service_bus_sender is not None:
+            try:
+                self._send_to_service_bus(docs)
+                return
+            except Exception:  # noqa: BLE001
+                logger.warning(
+                    "analytics.service_bus.send_failed — falling back to direct Cosmos write",
+                    exc_info=True,
+                )
+
+        # Fallback: write directly to Cosmos DB
+        if self._repository is not None:
+            for doc in docs:
+                try:
+                    self._repository.create(doc)
+                except Exception:  # noqa: BLE001
+                    logger.warning("analytics.cosmos.write_failed", exc_info=True)
+
+    def _send_to_service_bus(self, docs: list[dict[str, Any]]) -> None:
+        """Batch-send documents to the Service Bus topic."""
+        from azure.servicebus import ServiceBusMessage
+
+        batch = self._service_bus_sender.create_message_batch()  # type: ignore[union-attr]
+        for doc in docs:
+            message = ServiceBusMessage(
+                body=json.dumps(doc),
+                content_type="application/json",
+                application_properties={"eventType": doc.get("eventType", "unknown")},
+            )
+            try:
+                batch.add_message(message)
+            except ValueError:
+                # ValueError is raised for two reasons:
+                # 1. Batch is full — send what we have and start a new batch.
+                # 2. Single message exceeds SB max size (256 KB Standard) — in
+                #    this case the retry also raises ValueError, which
+                #    propagates to _persist_events and triggers Cosmos fallback.
+                self._service_bus_sender.send_messages(batch)  # type: ignore[union-attr]
+                batch = self._service_bus_sender.create_message_batch()  # type: ignore[union-attr]
+                batch.add_message(message)
+        if len(batch) > 0:
+            self._service_bus_sender.send_messages(batch)  # type: ignore[union-attr]
 
     # ------------------------------------------------------------------
     # Aggregation queries (used by GET endpoints)

--- a/src/bff/pyproject.toml
+++ b/src/bff/pyproject.toml
@@ -11,6 +11,7 @@ dependencies = [
     "azure-cosmos>=4.9.0",
     "azure-identity>=1.21.0",
     "azure-search-documents>=11.6.0",
+    "azure-servicebus>=7.13.0",
     "cryptography>=46.0.7",
     "fastapi>=0.135.3",
     "openai>=2.32.0",

--- a/src/bff/tests/test_analytics_service.py
+++ b/src/bff/tests/test_analytics_service.py
@@ -254,6 +254,84 @@ class TestAnalyticsServiceCosmosPersistence:
         repo = _make_mock_repo()
         repo.create.side_effect = RuntimeError("Cosmos unavailable")
         service = AnalyticsService(repository=repo)
-        # The exception should be caught and the event counted as failed.
+        # Enrichment succeeds, persistence failure is logged but doesn't affect
+        # the accepted count — events are "accepted" at enrichment time.
         result = service.record_events([_make_envelope("page_view")])
-        assert result == 0  # event was not recorded due to repo error
+        assert result == 1
+
+
+# ---------------------------------------------------------------------------
+# AnalyticsService — Service Bus path
+# ---------------------------------------------------------------------------
+
+
+def _make_mock_sb_sender() -> MagicMock:
+    """Return a mock ServiceBusSender with a mock batch."""
+    sender = MagicMock()
+    batch = MagicMock()
+    batch.__len__ = MagicMock(return_value=1)
+    sender.create_message_batch.return_value = batch
+    return sender
+
+
+class TestAnalyticsServiceServiceBus:
+    def test_sends_events_to_service_bus_when_configured(self) -> None:
+        sb_sender = _make_mock_sb_sender()
+        service = AnalyticsService(service_bus_sender=sb_sender)
+        result = service.record_events([_make_envelope("page_view")])
+        assert result == 1
+        sb_sender.send_messages.assert_called_once()
+
+    def test_sends_batch_to_service_bus(self) -> None:
+        sb_sender = _make_mock_sb_sender()
+        service = AnalyticsService(service_bus_sender=sb_sender)
+        service.record_events([_make_envelope("page_view"), _make_envelope("api_view")])
+        sb_sender.send_messages.assert_called_once()
+
+    def test_message_has_event_type_application_property(self) -> None:
+        sb_sender = _make_mock_sb_sender()
+        service = AnalyticsService(service_bus_sender=sb_sender)
+        service.record_events([_make_envelope("api_view")])
+        # The batch.add_message call receives a ServiceBusMessage
+        batch = sb_sender.create_message_batch.return_value
+        msg = batch.add_message.call_args[0][0]
+        assert msg.application_properties["eventType"] == "api_view"
+
+    def test_falls_back_to_cosmos_on_sb_failure(self) -> None:
+        sb_sender = _make_mock_sb_sender()
+        sb_sender.create_message_batch.side_effect = RuntimeError("SB down")
+        repo = _make_mock_repo()
+        service = AnalyticsService(repository=repo, service_bus_sender=sb_sender)
+        result = service.record_events([_make_envelope("page_view")])
+        assert result == 1
+        # Should have fallen back to Cosmos
+        assert repo.create.call_count == 1
+
+    def test_sb_preferred_over_cosmos_when_both_configured(self) -> None:
+        sb_sender = _make_mock_sb_sender()
+        repo = _make_mock_repo()
+        service = AnalyticsService(repository=repo, service_bus_sender=sb_sender)
+        service.record_events([_make_envelope("page_view")])
+        # SB should be used, NOT Cosmos
+        sb_sender.send_messages.assert_called_once()
+        repo.create.assert_not_called()
+
+    def test_no_sb_no_repo_still_logs(self) -> None:
+        service = AnalyticsService()
+        result = service.record_events([_make_envelope("page_view")])
+        assert result == 1
+
+    def test_falls_back_to_cosmos_when_single_message_exceeds_sb_max_size(self) -> None:
+        """When a message is too large for even an empty SB batch, the retry
+        add_message also raises ValueError. This should propagate to
+        _persist_events and trigger the Cosmos fallback."""
+        sb_sender = _make_mock_sb_sender()
+        batch = sb_sender.create_message_batch.return_value
+        # First add_message fails (message oversized), retry also fails
+        batch.add_message.side_effect = ValueError("Message too large")
+        repo = _make_mock_repo()
+        service = AnalyticsService(repository=repo, service_bus_sender=sb_sender)
+        result = service.record_events([_make_envelope("page_view")])
+        assert result == 1
+        # Should have fallen back to Cosmos
+        assert repo.create.call_count == 1

--- a/src/bff/uv.lock
+++ b/src/bff/uv.lock
@@ -166,6 +166,7 @@ dependencies = [
     { name = "azure-identity" },
     { name = "azure-monitor-opentelemetry" },
     { name = "azure-search-documents" },
+    { name = "azure-servicebus" },
     { name = "cryptography" },
     { name = "fastapi" },
     { name = "openai" },
@@ -198,6 +199,7 @@ requires-dist = [
     { name = "azure-identity", specifier = ">=1.21.0" },
     { name = "azure-monitor-opentelemetry", specifier = ">=1.6.4" },
     { name = "azure-search-documents", specifier = ">=11.6.0" },
+    { name = "azure-servicebus", specifier = ">=7.13.0" },
     { name = "cryptography", specifier = ">=46.0.7" },
     { name = "fastapi", specifier = ">=0.135.3" },
     { name = "openai", specifier = ">=2.32.0" },
@@ -356,6 +358,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/cf/68/9d59a0bed5fd9581b45444e8abc3ecda97e0466ae0f03affc7cddfb9fa74/azure_search_documents-11.6.0.tar.gz", hash = "sha256:fcc807076ff82024be576ffccb0d0f3261e5c2a112a6666b86ec70bbdb2e1d64", size = 311194, upload-time = "2025-10-09T22:04:03.655Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c5/4c/d74e5c3ccc0b9ead0e400a2d70ded67554b56a5d799aaa8bf5baaacf4aea/azure_search_documents-11.6.0-py3-none-any.whl", hash = "sha256:c3eb2deaf7926844e99a881830861225ef68e8b3bc067a76019e87fc7f5586dc", size = 307935, upload-time = "2025-10-09T22:04:05.008Z" },
+]
+
+[[package]]
+name = "azure-servicebus"
+version = "7.14.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "azure-core" },
+    { name = "isodate" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a8/d2/a5c11d4c955e2875de2383c1af8e43ce4899e8418b22e61d32d2bf103626/azure_servicebus-7.14.3.tar.gz", hash = "sha256:70a63384557aec0bee727740e7b25ded29e9e701b77611764577fd7402389402", size = 534786, upload-time = "2025-10-31T05:30:03.342Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/04/e9/d9fd0b2bef14d85b408c51802142b1c8b7bc3ab08514c89432547b1d87d3/azure_servicebus-7.14.3-py3-none-any.whl", hash = "sha256:386f8d32dae8881661ec8d791c38978eca2bbf7ea9f489d6cff8ad9cc6990234", size = 412522, upload-time = "2025-10-31T05:30:05.252Z" },
 ]
 
 [[package]]

--- a/src/frontend/app/catalog/[apiId]/components/__tests__/SpecDownloadButton.test.tsx
+++ b/src/frontend/app/catalog/[apiId]/components/__tests__/SpecDownloadButton.test.tsx
@@ -3,19 +3,34 @@ import SpecDownloadButton from '../SpecDownloadButton';
 
 describe('SpecDownloadButton', () => {
   it('renders download button', () => {
-    render(<SpecDownloadButton specContent='{"openapi":"3.0.0"}' apiId="test-api-1" apiName="test" versionId="v1" />);
+    render(
+      <SpecDownloadButton
+        specContent='{"openapi":"3.0.0"}'
+        apiId="test-api-1"
+        apiName="test"
+        versionId="v1"
+      />
+    );
     expect(screen.getByTestId('spec-download-button')).toBeInTheDocument();
     expect(screen.getByText('Download Spec')).toBeInTheDocument();
   });
 
   it('is disabled when specContent is null', () => {
-    render(<SpecDownloadButton specContent={null} apiId="test-api-1" apiName="test" versionId="v1" />);
+    render(
+      <SpecDownloadButton specContent={null} apiId="test-api-1" apiName="test" versionId="v1" />
+    );
     expect(screen.getByTestId('spec-download-button')).toBeDisabled();
   });
 
   it('is disabled when disabled prop is true', () => {
     render(
-      <SpecDownloadButton specContent='{"test": true}' apiId="test-api-1" apiName="test" versionId="v1" disabled />
+      <SpecDownloadButton
+        specContent='{"test": true}'
+        apiId="test-api-1"
+        apiName="test"
+        versionId="v1"
+        disabled
+      />
     );
     expect(screen.getByTestId('spec-download-button')).toBeDisabled();
   });
@@ -51,7 +66,12 @@ describe('SpecDownloadButton', () => {
       });
 
       render(
-        <SpecDownloadButton specContent='{"openapi":"3.0.0"}' apiId="petstore-api" apiName="petstore" versionId="v1" />
+        <SpecDownloadButton
+          specContent='{"openapi":"3.0.0"}'
+          apiId="petstore-api"
+          apiName="petstore"
+          versionId="v1"
+        />
       );
       fireEvent.click(screen.getByTestId('spec-download-button'));
       expect(createObjectURL).toHaveBeenCalled();


### PR DESCRIPTION
This pull request introduces full CI/CD and infrastructure support for the new `analytics-processor` service. It adds build, test, and lint steps for the service in the CI pipeline, provisions all required Azure resources and identities, and integrates deployment of the service across dev, staging, and prod environments. Additionally, it ensures the necessary environment variables and outputs are wired through the workflows and infrastructure code.

The most important changes are:

**CI/CD Pipeline Integration**
- Added linting, formatting, testing, and build steps for `src/analytics-processor` to the main CI workflow (`.github/workflows/ci.yml`). [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR69-R76) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fR317-R362)
- Included `analytics-processor` in the container build matrix in the deployment workflow (`.github/workflows/deploy-app.yml`).

**Deployment Automation**
- Added deployment steps for `analytics-processor` using Bicep templates in dev, staging, and prod stages of the deploy workflow (`.github/workflows/deploy-app.yml`). [[1]](diffhunk://#diff-7230a3559048fcc2ba14a726875d84cc74b726e7b8003611596cc2bd92ac5581R150-R168) [[2]](diffhunk://#diff-7230a3559048fcc2ba14a726875d84cc74b726e7b8003611596cc2bd92ac5581R213-R231) [[3]](diffhunk://#diff-7230a3559048fcc2ba14a726875d84cc74b726e7b8003611596cc2bd92ac5581R275-R293)
- Wired new environment variables (such as `SERVICE_BUS_NAMESPACE`) into the BFF deployment for all environments to support integration with the analytics processor. [[1]](diffhunk://#diff-7230a3559048fcc2ba14a726875d84cc74b726e7b8003611596cc2bd92ac5581L135-R137) [[2]](diffhunk://#diff-7230a3559048fcc2ba14a726875d84cc74b726e7b8003611596cc2bd92ac5581L179-R200) [[3]](diffhunk://#diff-7230a3559048fcc2ba14a726875d84cc74b726e7b8003611596cc2bd92ac5581L223-R263)

**Infrastructure as Code Enhancements**
- Defined new resource names and modules in `infra/main.bicep` for the analytics processor identity, app, service bus, and function storage. [[1]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R100) [[2]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R114-R116) [[3]](diffhunk://#diff-7ef659fc9cf6968e718894d300490b14ea7a52091e7d4bcffae3a5029ac721d4R187-R196)
- Passed the analytics processor managed identity to the container registry module for proper permissions.

**Workflow Outputs and Variable Propagation**
- Added outputs for all analytics processor resources (app name, identity IDs, service bus namespace, storage account) in the infrastructure workflow, and propagated them through job outputs for use in deployment workflows (`.github/workflows/deploy-infra.yml`). [[1]](diffhunk://#diff-4c19f571e78aef48c8dbd1f55a643094ff0688cbdafd9babb7962cf7443a5c2dR87-R101) [[2]](diffhunk://#diff-4c19f571e78aef48c8dbd1f55a643094ff0688cbdafd9babb7962cf7443a5c2dR164-R168) [[3]](diffhunk://#diff-4c19f571e78aef48c8dbd1f55a643094ff0688cbdafd9babb7962cf7443a5c2dR212-R216)