### PR TITLE
updated bicep for da func

### DIFF
--- a/infra/modules/analytics-processor.bicep
+++ b/infra/modules/analytics-processor.bicep
@@ -1,15 +1,20 @@
 // ============================================================================
-// Analytics Processor Function App Module (Microsoft.Web/sites on ACA)
+// Analytics Processor Function App Module
+// (Microsoft.App/containerApps, kind='functionapp')
 // ============================================================================
-// Deploys the analytics-processor as a classic Function App
-// (Microsoft.Web/sites kind=functionapp,linux,container,azurecontainerapps)
-// hosted on the existing Azure Container Apps managed environment.
+// Deploys the analytics-processor as a NATIVE Functions-on-ACA container app
+// — the v2 / recommended hosting model where the Functions runtime is
+// provided by the Azure Container Apps platform.
 //
-// We picked this hosting mode (over Microsoft.App/containerApps with
-// kind=functionapp) because the App Service control plane is a battle-tested
-// path for identity-based AzureWebJobsStorage / Service Bus / Cosmos DB
-// connections; the kind=functionapp ACA path failed to initialise the
-// Functions host's external startup classes in this project.
+// Replaces the legacy v1 proxy model
+// (Microsoft.Web/sites kind='functionapp,linux,container,azurecontainerapps')
+// which produced no first-class Container App resource, left the App Service
+// Functions blade in a broken "Runtime version: Error" state, and offered
+// no live logs / direct diagnostics.
+//
+// Refs:
+//   https://learn.microsoft.com/azure/container-apps/functions-overview
+//   https://learn.microsoft.com/azure/container-apps/migrate-functions
 // ============================================================================
 
 @description('Azure region')
@@ -51,6 +56,18 @@ param workloadProfileName string = 'Consumption'
 @description('Log Analytics Workspace resource ID for diagnostic settings')
 param logAnalyticsWorkspaceId string
 
+@description('CPU cores per replica')
+param cpuCore string = '0.5'
+
+@description('Memory per replica (e.g. 1Gi)')
+param memorySize string = '1'
+
+@description('Minimum replicas (0 enables scale-to-zero)')
+param minReplicas int = 0
+
+@description('Maximum replicas')
+param maxReplicas int = 10
+
 @description('Resource tags')
 param tags object = {
   Application: 'APIC-Vibe-Portal'
@@ -66,11 +83,15 @@ param tags object = {
 // built and pushed to ACR — so the image always exists at deploy time.
 var containerImage = '${acrLoginServer}/analytics-processor:${imageTag}'
 
-resource analyticsProcessor 'Microsoft.Web/sites@2024-04-01' = {
+resource analyticsProcessor 'Microsoft.App/containerApps@2024-10-02-preview' = {
   name: containerAppName
   location: location
   tags: tags
-  kind: 'functionapp,linux,container,azurecontainerapps'
+  // kind='functionapp' opts this Container App into the native Azure Functions
+  // hosting integration. The ACA platform injects the Functions host runtime;
+  // our image only needs to ship the worker + function code (standard
+  // mcr.microsoft.com/azure-functions/python base image).
+  kind: 'functionapp'
   identity: {
     type: 'UserAssigned'
     userAssignedIdentities: {
@@ -78,85 +99,83 @@ resource analyticsProcessor 'Microsoft.Web/sites@2024-04-01' = {
     }
   }
   properties: {
-    // Bind to the Container Apps managed environment (no serverFarmId).
-    managedEnvironmentId: containerAppsEnvironmentId
+    environmentId: containerAppsEnvironmentId
     workloadProfileName: workloadProfileName
-    httpsOnly: true
-    clientAffinityEnabled: false
-    // NOTE: `functionAppConfig` (runtime / scaleAndConcurrency / deployment) is
-    // a Flex Consumption property and is silently ignored for the
-    // `functionapp,linux,container,azurecontainerapps` kind — the RP returns
-    // null on read regardless of what we send. ACA-hosted Function Apps are
-    // configured purely through siteConfig.linuxFxVersion (the container image)
-    // and the Container Apps environment. The Azure portal Functions blade
-    // ("Runtime version: Error", empty Functions list) is a known cosmetic
-    // limitation for this hosting kind — the App Service Functions blade does
-    // not fully introspect ACA-hosted apps. Use the Container App resource
-    // blade or Application Insights for management/observability.
-    siteConfig: {
-      linuxFxVersion: 'DOCKER|${containerImage}'
-      // Pull the image from ACR using the user-assigned managed identity.
-      // For Functions on ACA, this property requires the UAMI *resource ID*
-      // (not its clientId) per the Azure validation error 51021.
-      acrUseManagedIdentityCreds: true
-      acrUserManagedIdentityID: managedIdentityResourceId
-      // App settings = Function host configuration. Identity-based connections
-      // are configured per-binding using the documented "__credential" /
-      // "__clientId" pattern. AZURE_CLIENT_ID is intentionally NOT set —
-      // each connection prefix carries its own identity client ID.
-      appSettings: [
-        // -------- Functions runtime --------
-        { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }
-        { name: 'FUNCTIONS_WORKER_RUNTIME', value: 'python' }
-
-        // -------- Container registry (required for linux,container) --------
-        // For Functions on Azure Container Apps, the underlying ACA registry
-        // validator requires a hostname-only value (no scheme), even though
-        // classic App Service expected `https://...`. The ACA error
-        // ContainerAppInvalidRegistryServerValue is the binding constraint.
-        { name: 'DOCKER_REGISTRY_SERVER_URL', value: acrLoginServer }
-
-        // -------- Telemetry --------
-        { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appInsightsConnectionString }
-
-        // -------- AzureWebJobsStorage (identity-based) --------
-        // Use the __accountName shorthand so the host derives blob/queue/table
-        // endpoints internally with the constructor signature its diagnostic
-        // event TableServiceClient factory expects. Setting the per-service
-        // *ServiceUri keys causes "Unable to find matching constructor" errors
-        // in the host's diagnostic logger.
-        { name: 'AzureWebJobsStorage__accountName', value: storageAccountName }
-        { name: 'AzureWebJobsStorage__credential', value: 'managedidentity' }
-        { name: 'AzureWebJobsStorage__clientId', value: managedIdentityClientId }
-
-        // -------- Service Bus trigger (identity-based) --------
-        { name: 'ServiceBusConnection__fullyQualifiedNamespace', value: serviceBusNamespace }
-        { name: 'ServiceBusConnection__credential', value: 'managedidentity' }
-        { name: 'ServiceBusConnection__clientId', value: managedIdentityClientId }
-
-        // -------- Cosmos DB output binding (identity-based) --------
-        { name: 'CosmosDBConnection__accountEndpoint', value: cosmosDbEndpoint }
-        { name: 'CosmosDBConnection__credential', value: 'managedidentity' }
-        { name: 'CosmosDBConnection__clientId', value: managedIdentityClientId }
+    configuration: {
+      activeRevisionsMode: 'Single'
+      // No ingress: the analytics-processor is triggered exclusively by a
+      // Service Bus queue. Adding ingress would cost an unnecessary public
+      // FQDN and broaden the attack surface.
+      // ACR pull via user-assigned managed identity (no admin user / no
+      // password secrets).
+      registries: [
+        {
+          server: acrLoginServer
+          identity: managedIdentityResourceId
+        }
       ]
+    }
+    template: {
+      containers: [
+        {
+          name: 'analytics-processor'
+          image: containerImage
+          resources: {
+            cpu: json(cpuCore)
+            memory: '${memorySize}Gi'
+          }
+          // Functions host configuration. Identity-based connections use the
+          // documented "__credential" / "__clientId" pattern. AZURE_CLIENT_ID
+          // is intentionally NOT set — each connection prefix carries its own
+          // identity client ID.
+          env: [
+            // -------- Functions runtime --------
+            { name: 'FUNCTIONS_EXTENSION_VERSION', value: '~4' }
+            { name: 'FUNCTIONS_WORKER_RUNTIME', value: 'python' }
+
+            // -------- Telemetry --------
+            { name: 'APPLICATIONINSIGHTS_CONNECTION_STRING', value: appInsightsConnectionString }
+
+            // -------- AzureWebJobsStorage (identity-based) --------
+            // __accountName shorthand lets the host derive blob/queue/table
+            // endpoints internally with the constructor signature its
+            // diagnostic event TableServiceClient factory expects.
+            { name: 'AzureWebJobsStorage__accountName', value: storageAccountName }
+            { name: 'AzureWebJobsStorage__credential', value: 'managedidentity' }
+            { name: 'AzureWebJobsStorage__clientId', value: managedIdentityClientId }
+
+            // -------- Service Bus trigger (identity-based) --------
+            { name: 'ServiceBusConnection__fullyQualifiedNamespace', value: serviceBusNamespace }
+            { name: 'ServiceBusConnection__credential', value: 'managedidentity' }
+            { name: 'ServiceBusConnection__clientId', value: managedIdentityClientId }
+
+            // -------- Cosmos DB output binding (identity-based) --------
+            { name: 'CosmosDBConnection__accountEndpoint', value: cosmosDbEndpoint }
+            { name: 'CosmosDBConnection__credential', value: 'managedidentity' }
+            { name: 'CosmosDBConnection__clientId', value: managedIdentityClientId }
+          ]
+        }
+      ]
+      scale: {
+        minReplicas: minReplicas
+        maxReplicas: maxReplicas
+      }
     }
   }
 }
 
 // ----------------------------------------------------------------------------
-// Diagnostic settings — required by project policy. Sends function host logs,
-// platform logs, and metrics to Log Analytics for centralised observability.
+// Diagnostic settings — required by project policy.
+// Container console + system logs are captured by the managed environment's
+// appLogsConfiguration (configured at the env level) and flow to the same
+// Log Analytics workspace. Here we additionally enable platform metrics on
+// the Container App resource for centralised observability and alerting.
 // ----------------------------------------------------------------------------
 resource diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-preview' = {
   name: 'send-to-log-analytics'
   scope: analyticsProcessor
   properties: {
     workspaceId: logAnalyticsWorkspaceId
-    logs: [
-      { category: 'FunctionAppLogs', enabled: true }
-      { category: 'AppServiceConsoleLogs', enabled: true }
-      { category: 'AppServicePlatformLogs', enabled: true }
-    ]
     metrics: [
       { category: 'AllMetrics', enabled: true }
     ]
@@ -167,11 +186,11 @@ resource diagnosticSettings 'Microsoft.Insights/diagnosticSettings@2021-05-01-pr
 // OUTPUTS
 // ============================================================================
 
-@description('Analytics processor Function App resource ID')
+@description('Analytics processor Container App resource ID')
 output id string = analyticsProcessor.id
 
-@description('Analytics processor Function App name')
+@description('Analytics processor Container App name')
 output name string = analyticsProcessor.name
 
-@description('Analytics processor Function App default hostname')
-output defaultHostName string = analyticsProcessor.properties.defaultHostName
+@description('Analytics processor Container App FQDN (empty when ingress is disabled)')
+output defaultHostName string = ''


### PR DESCRIPTION
This pull request modernizes the deployment of the `analytics-processor` by migrating from the legacy Azure Functions-on-App Service model to the native Functions-on-Azure Container Apps (ACA) model. The new approach leverages the latest recommended hosting pattern, improves diagnostics and observability, and introduces more flexible resource and scaling configuration.

Key changes include:

**Migration to Native Functions-on-ACA:**
* Replaces the legacy `Microsoft.Web/sites` (App Service) resource with a `Microsoft.App/containerApps` resource using `kind='functionapp'`, adopting the v2 native Functions-on-ACA hosting model for improved integration, diagnostics, and management. [[1]](diffhunk://#diff-03a6d002e0115c93198d7c5c1c3d86a1b219a38af2b66d83af2421a9d1186bbdL2-R17) [[2]](diffhunk://#diff-03a6d002e0115c93198d7c5c1c3d86a1b219a38af2b66d83af2421a9d1186bbdL69-R142)

**Resource and Scaling Configuration:**
* Adds parameters for CPU, memory, and replica scaling (`cpuCore`, `memorySize`, `minReplicas`, `maxReplicas`), allowing fine-grained control over resource allocation and autoscaling behavior. [[1]](diffhunk://#diff-03a6d002e0115c93198d7c5c1c3d86a1b219a38af2b66d83af2421a9d1186bbdR59-R70) [[2]](diffhunk://#diff-03a6d002e0115c93198d7c5c1c3d86a1b219a38af2b66d83af2421a9d1186bbdL69-R142)

**Container App Resource Definition:**
* Updates the resource definition to use ACA-native configuration blocks (`configuration`, `template`, `scale`) and environment variable setup, including identity-based connections and registry authentication. [[1]](diffhunk://#diff-03a6d002e0115c93198d7c5c1c3d86a1b219a38af2b66d83af2421a9d1186bbdL69-R142) [[2]](diffhunk://#diff-03a6d002e0115c93198d7c5c1c3d86a1b219a38af2b66d83af2421a9d1186bbdR158-L159)

**Diagnostics and Observability:**
* Refactors diagnostic settings to focus on platform metrics, with logs now collected at the environment level via ACA's `appLogsConfiguration`, streamlining observability and compliance.

**Outputs and Documentation:**
* Updates output variables and documentation to reflect the new Container App resource, clarifying the absence of a default FQDN when ingress is disabled.