### PR TITLE
added new spec/plan docs

### DIFF
--- a/docs/project/plan/036-mcp-capability-indexing.md
+++ b/docs/project/plan/036-mcp-capability-indexing.md
@@ -1,0 +1,189 @@
+# 036 - MCP Capability Indexing
+
+> **🔲 Status: Not Started**
+>
+> _This is a living document. Status and implementation notes are updated as work progresses._
+
+## References
+
+- [Architecture Document](../apic_architecture.md) — Search Layer (AI Search), Persistence (Cosmos DB)
+- [Product Charter](../apic_product_charter.md) — Improve API discovery
+- [013 — AI Search Index Setup & Indexing Pipeline](013-ai-search-index-setup.md)
+- [014 — Search API Implementation](014-search-api-implementation.md)
+- [033 — MCP Inspector Integration](033-mcp-inspector-integration.md) — capability shape (`McpTool`, `McpPrompt`, `McpResource`)
+
+## Overview
+
+Today the catalog and search index API-level metadata (name, description, lifecycle, etc.). For MCP-kind APIs, the **most useful unit of discovery is a tool, not a server** — developers search for "convert markdown to pdf," not for a server that happens to contain that capability.
+
+This task captures the tools, prompts, and resources declared in each MCP API's APIC definition payload, projects them as child documents into AI Search, and persists a structured snapshot in Cosmos DB so downstream features (drift detection, governance, comparison) can read a stable shape.
+
+The capture source is **the API Center definition document** for each `kind=mcp` API version — _not_ a live `tools/list` call against the upstream server. The indexer runs as a scheduled Container Apps Job and must work without inbound network access to MCP endpoints.
+
+## Dependencies
+
+- **009** — API Center data layer (definition export)
+- **013** — AI Search index setup (index schema)
+- **016** — Persistence baseline (Cosmos DB containers, repository pattern)
+- **033** — MCP Inspector Integration (capability Pydantic models in `models/mcp.py`)
+
+## Implementation Details
+
+### 1. Capability Snapshot Schema
+
+Add a new Cosmos DB container `mcp-capability-snapshots` (partition key `/apiId`).
+
+```typescript
+interface McpCapabilitySnapshot {
+  id: string;                  // `${apiId}__${versionName}`
+  apiId: string;
+  apiName: string;
+  versionName: string;
+  capturedAt: string;          // ISO timestamp
+  source: 'apic-definition';   // reserved for future 'live-probe'
+  definitionHash: string;      // sha256 of normalized definition payload
+  tools: McpTool[];            // shape from models/mcp.py
+  prompts: McpPrompt[];
+  resources: McpResource[];
+  toolCount: number;
+  promptCount: number;
+  resourceCount: number;
+  schemaVersion: 1;
+}
+```
+
+Hash is computed over a normalized JSON form (sorted keys, stripped whitespace) so unchanged payloads do not trigger search reindex churn.
+
+### 2. Definition Parser
+
+```
+src/shared/src/mcp/
+├── definition-parser.ts       # Parse APIC MCP definition → McpCapabilitySnapshot
+└── definition-parser.test.ts
+```
+
+A pure function `parseMcpDefinition(rawDefinition: unknown): ParsedCapabilities` that:
+
+- Accepts the JSON payload returned by `export_api_specification` for `kind=mcp` APIs.
+- Tolerates two layouts: (a) MCP-spec-style `{ tools: [...], prompts: [...], resources: [...] }` and (b) a wrapping `capabilities` object — log and pick whichever is present.
+- Validates each tool/prompt/resource against the existing Pydantic / TS shapes; drops malformed entries with a warning rather than failing the whole snapshot.
+- Returns counts plus a list of validation issues for governance to consume.
+
+A matching Python implementation lives in `src/bff/apic_vibe_portal_bff/services/mcp_definition_parser.py` so both the indexer and the BFF can use it.
+
+### 3. Indexer Worker Changes
+
+Extend the existing `src/indexer/` Container Apps Job:
+
+- For each API where `kind == 'mcp'`, fetch the latest version's primary definition via `list_api_definitions` + `export_api_specification`.
+- Parse with the shared parser; compute `definitionHash`.
+- Upsert the snapshot into Cosmos. Skip the AI Search reindex step when the new hash matches the existing snapshot.
+- Emit App Insights telemetry: `mcp_indexer.captured`, `mcp_indexer.unchanged`, `mcp_indexer.parse_failed` with `apiId` / `versionName` / counts.
+
+### 4. AI Search Index Changes
+
+Extend `src/indexer/indexer/index_schema.py` to add a second index (or sibling fields) for **MCP capability** documents — one document per tool / prompt / resource:
+
+| Field             | Type    | Notes                                     |
+| ----------------- | ------- | ----------------------------------------- |
+| `id`              | string  | `${apiId}__${versionName}__tool__${name}` |
+| `apiId`           | string  | filterable, faceted                       |
+| `apiName`         | string  |                                           |
+| `versionName`     | string  | filterable                                |
+| `capabilityType`  | string  | `tool` / `prompt` / `resource`            |
+| `capabilityName`  | string  | searchable                                |
+| `description`     | string  | searchable                                |
+| `parameterNames`  | string[]| from input schema                         |
+| `embedding`       | vector  | name + description + params               |
+| `lastIndexedAt`   | dateTime|                                           |
+
+Use a **separate index** (`mcp-capabilities`) to keep facets, scoring, and TTL independent from the existing api-level index.
+
+### 5. BFF — Search Surface
+
+```
+src/bff/apic_vibe_portal_bff/services/mcp_capability_search_service.py
+src/bff/apic_vibe_portal_bff/routers/mcp_search.py
+```
+
+New endpoint:
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET`  | `/api/mcp/capabilities/search?q=&type=&top=` | Hybrid search across tool/prompt/resource docs |
+
+- Same RBAC + security trimming as `/api/search`. Filter results to `apiId`s the caller can see.
+- Returns each hit with `apiId`, `apiName`, `capabilityType`, `capabilityName`, `description`, and a back-link to the API detail page.
+
+A read-only `getSnapshot(apiId, versionName)` accessor on the same service exposes the full Cosmos snapshot for downstream tasks (drift, comparison).
+
+### 6. Frontend — Capability-Level Search Results
+
+- Add a "Tools" tab to the global search page (`app/search/page.tsx`) that calls the new endpoint.
+- Each hit links to the API detail page with `?tab=inspector&tool=<name>` so the existing Inspector tab pre-selects the matching tool.
+
+### 7. Catalog Card — Tool Count Chip
+
+On `app/catalog/components/ApiCard.tsx`, for MCP APIs, render a small chip "N tools" sourced from the snapshot's `toolCount`. Read from the snapshot, not a live probe.
+
+## Testing & Acceptance Criteria
+
+- [ ] Shared parser handles both definition layouts and rejects malformed tool/prompt/resource entries with structured warnings.
+- [ ] Indexer captures a snapshot for every `kind=mcp` API in a test APIC fixture.
+- [ ] Indexer is idempotent — a second run with no source changes produces zero AI Search writes (verified via search client mock).
+- [ ] Cosmos snapshot includes `definitionHash`, `toolCount`, `promptCount`, `resourceCount`.
+- [ ] AI Search `mcp-capabilities` index has one document per tool/prompt/resource with correct `apiId` linkage.
+- [ ] `GET /api/mcp/capabilities/search?q=...` returns hits filtered by RBAC + security trimming.
+- [ ] Search page Tools tab renders results and deep-links into the Inspector tab with the tool pre-selected.
+- [ ] ApiCard renders a tool-count chip on MCP APIs.
+- [ ] Unit tests cover parser edge cases, indexer idempotency, search service filters.
+- [ ] E2E: Search "weather" finds a tool defined in a fixture MCP server.
+
+## Implementation Notes
+
+<!--
+  This section is a living record updated by the implementing agent.
+  Update status, log decisions, and record validation results as work progresses.
+  When complete, change the Status at the top of this document to ✅ Complete.
+-->
+
+### Status History
+
+| Date | Status         | Author | Notes        |
+| ---- | -------------- | ------ | ------------ |
+| —    | 🔲 Not Started | —      | Task created |
+
+### Technical Decisions
+
+_To be recorded by the implementing agent._
+
+### Deviations from Plan
+
+_To be recorded by the implementing agent._
+
+### Validation Results
+
+_To be recorded by the implementing agent._
+
+## Coding Agent Prompt
+
+```text
+**Task**: Implement plan step 036 — MCP Capability Indexing.
+
+Read the full task specification at `docs/project/plan/036-mcp-capability-indexing.md`.
+
+Reference `docs/project/plan/013-ai-search-index-setup.md` for the indexing pipeline, `docs/project/plan/016-persistence-data-governance-baseline.md` for the Cosmos repository pattern, and `docs/project/plan/033-mcp-inspector-integration.md` for the existing MCP capability models.
+
+Build a shared definition parser (TS + Python), extend the indexer Container Apps Job to capture MCP capability snapshots into a new Cosmos container, project each capability as a child document in a new `mcp-capabilities` AI Search index, and expose a hybrid-search BFF endpoint with RBAC + security trimming. Add a Tools tab to the search page and a tool-count chip to ApiCard.
+
+The indexer must NOT call live MCP servers. Source data exclusively from APIC definition exports. Indexing must be idempotent on unchanged definitions.
+
+Write unit tests (parser, indexer idempotency, search service) and one E2E test that finds a tool by name. Verify all tests pass.
+
+**Living Document Update**: After completing implementation, update this plan document:
+1. Change the status banner at the top to `> **✅ Status: Complete**`
+2. Add a row to the Status History table with the completion date and a summary
+3. Record any technical decisions made under "Technical Decisions"
+4. Note any deviations from the plan under "Deviations from Plan"
+5. Record test/validation results under "Validation Results"
+```

--- a/docs/project/plan/037-mcp-governance-rules.md
+++ b/docs/project/plan/037-mcp-governance-rules.md
@@ -1,0 +1,155 @@
+# 037 - MCP Governance & Best-Practices Rules
+
+> **🔲 Status: Not Started**
+>
+> _This is a living document. Status and implementation notes are updated as work progresses._
+
+## References
+
+- [Architecture Document](../apic_architecture.md) — Multi-agent design, Governance Agent
+- [Product Charter](../apic_product_charter.md) — Provide governance visibility
+- [023 — Governance & Compliance Agent](023-governance-agent.md) — rule engine + scoring
+- [025 — Governance Dashboard UI](025-governance-dashboard-ui.md)
+- [036 — MCP Capability Indexing](036-mcp-capability-indexing.md) — capability snapshot data source
+
+## Overview
+
+The existing governance rule engine (Task 023) checks API-level metadata (description, contacts, license, lifecycle, etc.). For MCP servers it leaves the most consequential surface — the **tools** themselves — completely unchecked. A server that exposes a `delete_everything` tool with no description and no input schema scores the same as one with carefully-typed, well-documented tools.
+
+This task adds a category of MCP-specific rules that operate on the capability snapshots produced by Task 036 and integrates them into the existing scoring, dashboard, and remediation flows. Rules cover **metadata quality, schema strictness, security posture, and naming hygiene** — all derived from data already in APIC, with no live network access required.
+
+## Dependencies
+
+- **023** — Governance Agent (rule engine, severity model, scoring, agent tools)
+- **025** — Governance Dashboard UI (presentation surface)
+- **036** — MCP Capability Indexing (capability snapshot data source)
+
+## Implementation Details
+
+### 1. Rule Authoring
+
+Add `src/bff/apic_vibe_portal_bff/agents/governance_agent/rules/mcp_rules.py` defining at least the following rules. Each rule operates on a `(api: dict, snapshot: McpCapabilitySnapshot | None)` pair so it can short-circuit gracefully on non-MCP APIs.
+
+**Metadata quality**
+
+| Rule ID                              | Severity | Description                                                |
+| ------------------------------------ | -------- | ---------------------------------------------------------- |
+| `mcp.tools.have_descriptions`        | warning  | Every tool has a non-empty `description` ≥ 20 chars        |
+| `mcp.tools.unique_names`             | critical | No duplicate tool names within the server                  |
+| `mcp.prompts.have_descriptions`      | info     | Every prompt has a description                             |
+| `mcp.resources.have_mime_type`       | info     | Every resource declares a `mimeType`                       |
+
+**Schema strictness**
+
+| Rule ID                              | Severity | Description                                                |
+| ------------------------------------ | -------- | ---------------------------------------------------------- |
+| `mcp.tools.input_schema_present`     | warning  | Every tool declares an `inputSchema` (object schema)       |
+| `mcp.tools.required_fields_declared` | warning  | Tools with input schemas declare a `required` array        |
+| `mcp.tools.no_freeform_object`       | info     | Tools do not accept untyped `additionalProperties: true`   |
+| `mcp.tools.parameter_descriptions`   | info     | ≥ 80 % of input parameters have descriptions               |
+
+**Security & risk posture**
+
+| Rule ID                              | Severity | Description                                                |
+| ------------------------------------ | -------- | ---------------------------------------------------------- |
+| `mcp.tools.destructive_verb_review`  | critical | Tools whose name matches `^(delete|drop|destroy|wipe|purge|truncate)_` MUST set a `destructive` annotation in the description (e.g. `[destructive]`) |
+| `mcp.tools.no_shell_passthrough`     | critical | No tool named `exec`, `shell`, `run_command`, or accepting a single string parameter named `command` / `cmd` without a documented allowlist |
+| `mcp.tools.auth_documented`          | warning  | API description references the auth scheme (Entra / OAuth / API key) the MCP server expects |
+| `mcp.tools.write_tools_capped`       | info     | Surface count of write-style tools (`create_*`, `update_*`, `delete_*`) so reviewers can spot scope creep |
+
+**Naming hygiene**
+
+| Rule ID                              | Severity | Description                                                |
+| ------------------------------------ | -------- | ---------------------------------------------------------- |
+| `mcp.tools.snake_case`               | info     | Tool names match `^[a-z][a-z0-9_]*$`                       |
+| `mcp.tools.no_ambiguous_names`       | info     | Tool name is not a single generic verb (`get`, `update`, `process`) |
+
+Each rule must include `remediation` text written for an API owner — concrete, copy-paste-actionable.
+
+### 2. Rule Engine Integration
+
+- Extend `compliance_checker.py` to thread the `snapshot` through to MCP rules.
+- Snapshots are fetched via the read accessor introduced in Task 036; missing snapshots short-circuit MCP rules to `not_applicable` (do _not_ count as failures).
+- MCP rules must **not** affect the scoring of non-MCP APIs (route via the existing `applicable_to` predicate).
+- Add a per-category breakdown to `ComplianceResult` so the dashboard can render MCP rule outcomes in their own group.
+
+### 3. Governance Agent Tools
+
+Add two new tools on the existing Governance Agent:
+
+- `getMcpRiskProfile(apiId)` — returns the destructive/write tool counts, schema-strictness score, and security flags for a single MCP server.
+- `listMcpServersFailingRule(ruleId)` — returns MCP APIs failing a specific rule, used by admin queries.
+
+Update the system prompt (`agents/prompts/governance_system.md`) so the agent can reason about MCP-specific concerns (destructive tools, schema strictness, auth documentation).
+
+### 4. Governance Dashboard UI
+
+`app/governance/` and `app/catalog/[apiId]/`:
+
+- On the API detail compliance tab for MCP APIs, render a **"MCP Capability Rules"** panel grouping the new rules with per-tool breakdowns (which specific tool failed which rule).
+- On the dashboard, add a filter chip "MCP Servers" that limits the view to `kind=mcp`.
+- Add a "Risk profile" mini-card to MCP API detail compliance: destructive tools count, write tools count, schema strictness %, auth documented yes/no.
+
+### 5. Telemetry & Backfill
+
+- Emit `governance.mcp_rule_evaluated` with `ruleId`, `apiId`, `passed`, `severity` for analytics.
+- The Governance worker's existing scheduled run picks up MCP rules automatically once snapshots exist; provide a one-shot CLI script `scripts/recompute-mcp-governance.py` for backfill.
+
+## Testing & Acceptance Criteria
+
+- [ ] All rules above implemented with rule IDs matching spec, each with remediation text.
+- [ ] Each rule has unit tests covering pass, fail, and `not_applicable` paths (≥ 3 tests per rule).
+- [ ] Non-MCP APIs see no change in score after MCP rules are introduced (regression test against fixture).
+- [ ] APIs with no capability snapshot evaluate MCP rules as `not_applicable`.
+- [ ] `getMcpRiskProfile` returns destructive/write counts, schema strictness, auth-documented flag.
+- [ ] `listMcpServersFailingRule` filters to MCP APIs only.
+- [ ] Governance dashboard renders MCP filter chip and risk-profile card.
+- [ ] Per-tool breakdown shows _which_ tool failed each rule (not just the server).
+- [ ] Backfill script processes a fixture APIC of ≥ 10 MCP APIs end-to-end.
+
+## Implementation Notes
+
+<!--
+  This section is a living record updated by the implementing agent.
+  Update status, log decisions, and record validation results as work progresses.
+  When complete, change the Status at the top of this document to ✅ Complete.
+-->
+
+### Status History
+
+| Date | Status         | Author | Notes        |
+| ---- | -------------- | ------ | ------------ |
+| —    | 🔲 Not Started | —      | Task created |
+
+### Technical Decisions
+
+_To be recorded by the implementing agent._
+
+### Deviations from Plan
+
+_To be recorded by the implementing agent._
+
+### Validation Results
+
+_To be recorded by the implementing agent._
+
+## Coding Agent Prompt
+
+```text
+**Task**: Implement plan step 037 — MCP Governance & Best-Practices Rules.
+
+Read the full task specification at `docs/project/plan/037-mcp-governance-rules.md`.
+
+Reference `docs/project/plan/023-governance-agent.md` for the rule engine, severity model, and scoring; `docs/project/plan/025-governance-dashboard-ui.md` for the dashboard surface; and `docs/project/plan/036-mcp-capability-indexing.md` for the capability snapshot data source.
+
+Add an MCP rule module under `agents/governance_agent/rules/mcp_rules.py` with rules covering metadata quality, schema strictness, security/risk posture (destructive verbs, shell passthrough, auth documentation), and naming hygiene. Integrate with the existing compliance checker so non-MCP APIs are unaffected and MCP APIs without a snapshot evaluate to not_applicable. Add `getMcpRiskProfile` and `listMcpServersFailingRule` agent tools. Extend the governance dashboard with an MCP filter chip, a per-tool failure breakdown, and a risk-profile mini-card on MCP detail pages.
+
+Write unit tests covering each rule (pass, fail, not_applicable) and a regression test verifying non-MCP API scores are unchanged. Verify all tests pass.
+
+**Living Document Update**: After completing implementation, update this plan document:
+1. Change the status banner at the top to `> **✅ Status: Complete**`
+2. Add a row to the Status History table with the completion date and a summary
+3. Record any technical decisions made under "Technical Decisions"
+4. Note any deviations from the plan under "Deviations from Plan"
+5. Record test/validation results under "Validation Results"
+```

--- a/docs/project/plan/038-mcp-capability-drift-detection.md
+++ b/docs/project/plan/038-mcp-capability-drift-detection.md
@@ -1,0 +1,209 @@
+# 038 - MCP Capability Drift Detection (Inter-Version)
+
+> **🔲 Status: Not Started**
+>
+> _This is a living document. Status and implementation notes are updated as work progresses._
+
+## References
+
+- [Architecture Document](../apic_architecture.md) — Persistence (Cosmos DB)
+- [Product Charter](../apic_product_charter.md) — Improve API discovery; metadata completeness
+- [009 — API Center Data Layer](009-api-center-data-layer.md)
+- [036 — MCP Capability Indexing](036-mcp-capability-indexing.md) — capability snapshot source
+- [037 — MCP Governance Rules](037-mcp-governance-rules.md)
+
+## Overview
+
+When an API owner publishes a new version of an MCP server in API Center, consumers need to know what changed: which tools were added, removed, or had their input schemas altered, and which prompts/resources moved. Today this requires manually reading two specs side-by-side.
+
+This task computes a **structured diff between two capability snapshots of the same MCP API** (typically consecutive versions) and surfaces it in the catalog UI as a "What's changed" view. It also triggers governance signals (e.g. "breaking change without major version bump") that the rule engine can act on.
+
+**Critical scope constraint**: The diff is computed exclusively between snapshots stored in Cosmos by Task 036 — i.e. between definition payloads registered in API Center. No live MCP endpoint is contacted. We do not assume the indexer or BFF can reach upstream MCP servers.
+
+## Dependencies
+
+- **036** — MCP Capability Indexing (snapshot source)
+- **037** — MCP Governance Rules (consumes drift events)
+- **019** — Application Insights (drift telemetry)
+
+## Implementation Details
+
+### 1. Diff Algorithm
+
+Add a shared TypeScript module and a Python mirror:
+
+```
+src/shared/src/mcp/capability-diff.ts
+src/bff/apic_vibe_portal_bff/services/mcp_capability_diff_service.py
+```
+
+Function signature:
+
+```typescript
+function diffCapabilities(
+  before: McpCapabilitySnapshot,
+  after: McpCapabilitySnapshot,
+): McpCapabilityDiff;
+
+interface McpCapabilityDiff {
+  apiId: string;
+  fromVersion: string;
+  toVersion: string;
+  tools: {
+    added: McpTool[];
+    removed: McpTool[];
+    changed: McpToolChange[];     // per-field diff
+    unchanged: number;
+  };
+  prompts: { added; removed; changed; unchanged };
+  resources: { added; removed; changed; unchanged };
+  breakingChanges: BreakingChange[];
+  changeKind: 'major' | 'minor' | 'patch' | 'none';
+}
+
+interface McpToolChange {
+  name: string;
+  descriptionChanged: boolean;
+  inputSchemaChanges: SchemaChange[];   // added/removed/typeChanged/requiredChanged
+  isBreaking: boolean;
+}
+```
+
+**Breaking change classification** (drives `changeKind`):
+
+| Change                                                 | Severity     |
+| ------------------------------------------------------ | ------------ |
+| Tool removed                                           | major        |
+| Required parameter added to existing tool              | major        |
+| Parameter type changed                                 | major        |
+| Resource URI removed                                   | major        |
+| Optional parameter added to existing tool              | minor        |
+| Tool added                                             | minor        |
+| Description-only change                                | patch        |
+| Prompt argument required → optional                    | minor        |
+
+The classification is a pure function — no LLM, no I/O — so it is deterministic and trivially testable.
+
+### 2. Persistence
+
+Add a `mcp-capability-diffs` Cosmos container (partition key `/apiId`) keyed by `${apiId}__${fromVersion}__${toVersion}`. Diffs are computed on demand and cached so the BFF does not recompute on every page load.
+
+### 3. Diff Trigger
+
+Two trigger paths:
+
+1. **Indexer-triggered**: When the indexer (Task 036) writes a new snapshot whose `definitionHash` differs from the previous snapshot for the same `apiId`, it enqueues a diff computation. The diff is persisted and a telemetry event `mcp.drift.detected` is emitted with `apiId`, `changeKind`, and counts.
+2. **On-demand**: BFF endpoint allows callers to request an arbitrary `(fromVersion, toVersion)` pair — used by the UI when a user picks two versions to compare.
+
+### 4. BFF Endpoints
+
+```
+src/bff/apic_vibe_portal_bff/routers/mcp_drift.py
+```
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET`  | `/api/mcp/{apiId}/drift/latest`                    | Diff between the latest version and the one before it |
+| `GET`  | `/api/mcp/{apiId}/drift?from=&to=`                 | Diff between two arbitrary versions of the same API   |
+| `GET`  | `/api/mcp/{apiId}/drift/history?limit=`            | List of historical diff records (changeKind + counts) |
+
+All endpoints enforce the same RBAC + security trimming as the catalog. 422 if either version has no snapshot; 404 if the API does not exist.
+
+### 5. Frontend — "What's Changed" Tab
+
+On the API detail page for `kind=mcp` APIs, add a new tab **Changes** alongside the existing Inspector tab.
+
+```
+app/catalog/[apiId]/components/McpChangesTab.tsx
+app/catalog/[apiId]/components/McpDriftSummaryCard.tsx
+app/catalog/[apiId]/components/McpToolDiffRow.tsx
+```
+
+UI elements:
+
+- Version selector (two dropdowns; default to latest two versions).
+- A summary chip showing `changeKind` (Major / Minor / Patch / None) with color.
+- Three collapsible sections (Tools, Prompts, Resources) listing added / removed / changed entries.
+- For changed tools, render a parameter-level diff: `+ required: city (string)`, `- type: number → string`.
+- A "Breaking changes" banner if any are present, with a link to the relevant tool sections.
+
+### 6. Governance Hook
+
+Task 037's rule engine gains a derived rule that consumes the latest diff:
+
+- `mcp.versioning.breaking_change_requires_major_bump` (severity: critical) — fails when the diff between two adjacent versions is `major` but the API's `version` string didn't increment its major component (best-effort regex on `^v?(\d+)\.`).
+
+This rule is added in 037's mcp_rules.py but its trigger lives here because the diff store is the data source.
+
+### 7. Telemetry
+
+Emit App Insights events:
+
+- `mcp.drift.detected` — `apiId`, `fromVersion`, `toVersion`, `changeKind`, `toolsAdded`, `toolsRemoved`, `toolsChanged`.
+- `mcp.drift.breaking_change` — for each entry in `breakingChanges`.
+
+These feed the analytics dashboard so platform owners can spot churn hotspots.
+
+## Testing & Acceptance Criteria
+
+- [ ] `diffCapabilities` is a pure function with no I/O dependencies.
+- [ ] Unit tests cover: tool added/removed/renamed; required-param added/removed; type changed; description-only change; prompts; resources; identical snapshots → `none`.
+- [ ] Breaking-change classification matches the table in §1 for every fixture case.
+- [ ] Diff is persisted to Cosmos and retrieved by `id`.
+- [ ] Indexer triggers diff computation only when `definitionHash` changes.
+- [ ] All three BFF endpoints enforce RBAC + security trimming.
+- [ ] `GET /api/mcp/{apiId}/drift?from=&to=` returns 422 when a snapshot is missing.
+- [ ] Frontend Changes tab renders for MCP APIs with ≥ 2 versions, hidden otherwise.
+- [ ] Parameter-level diff is shown for each changed tool.
+- [ ] Breaking-change banner appears only when `breakingChanges` is non-empty.
+- [ ] Governance rule `breaking_change_requires_major_bump` fires for the matching fixture.
+- [ ] E2E: User navigates to an MCP API with two versions, opens the Changes tab, and sees the expected added/removed/changed counts.
+
+## Implementation Notes
+
+<!--
+  This section is a living record updated by the implementing agent.
+  Update status, log decisions, and record validation results as work progresses.
+  When complete, change the Status at the top of this document to ✅ Complete.
+-->
+
+### Status History
+
+| Date | Status         | Author | Notes        |
+| ---- | -------------- | ------ | ------------ |
+| —    | 🔲 Not Started | —      | Task created |
+
+### Technical Decisions
+
+_To be recorded by the implementing agent._
+
+### Deviations from Plan
+
+_To be recorded by the implementing agent._
+
+### Validation Results
+
+_To be recorded by the implementing agent._
+
+## Coding Agent Prompt
+
+```text
+**Task**: Implement plan step 038 — MCP Capability Drift Detection (Inter-Version).
+
+Read the full task specification at `docs/project/plan/038-mcp-capability-drift-detection.md`.
+
+Reference `docs/project/plan/036-mcp-capability-indexing.md` for the snapshot data source, `docs/project/plan/037-mcp-governance-rules.md` for the consuming governance rule, and `docs/project/plan/019-observability-app-insights.md` for telemetry conventions.
+
+Implement a pure-function diff (TS in `src/shared`, Python mirror in the BFF service layer) over two capability snapshots, with explicit breaking-change classification. Persist computed diffs in a new `mcp-capability-diffs` Cosmos container. Trigger diff computation from the indexer when a new snapshot's `definitionHash` changes. Add three BFF endpoints (latest, arbitrary from/to, history) with RBAC + security trimming. Build the Changes tab in the API detail page with version pickers, change-kind chip, tool/prompt/resource diff sections, parameter-level diffs for changed tools, and a breaking-change banner. Wire `mcp.drift.detected` and `mcp.drift.breaking_change` App Insights events.
+
+The diff must NEVER call live MCP endpoints — operate exclusively on stored snapshots.
+
+Write unit tests for every diff and breaking-change case in §1 of the plan, plus an E2E test for the Changes tab.
+
+**Living Document Update**: After completing implementation, update this plan document:
+1. Change the status banner at the top to `> **✅ Status: Complete**`
+2. Add a row to the Status History table with the completion date and a summary
+3. Record any technical decisions made under "Technical Decisions"
+4. Note any deviations from the plan under "Deviations from Plan"
+5. Record test/validation results under "Validation Results"
+```

--- a/docs/project/plan/039-mcp-invocation-audit-log.md
+++ b/docs/project/plan/039-mcp-invocation-audit-log.md
@@ -1,0 +1,200 @@
+# 039 - MCP Invocation Audit Log
+
+> **🔲 Status: Not Started**
+>
+> _This is a living document. Status and implementation notes are updated as work progresses._
+
+## References
+
+- [Architecture Document](../apic_architecture.md) — Persistence (Cosmos DB), Observability
+- [PII Handling](../../architecture/pii-handling.md)
+- [Data Retention Policy](../../architecture/data-retention-policy.md)
+- [033 — MCP Inspector Integration](033-mcp-inspector-integration.md)
+- [020 — Security Trimming](020-security-trimming.md)
+- [028 — Analytics Data Collection](028-analytics-data-collection.md)
+
+## Overview
+
+Today the MCP Inspector invokes a tool and forgets — the result is shown to the caller and discarded. There is no audit trail, no usage signal for ranking tools in search, and no way for a security review to answer "who called what tool, when, with what arguments."
+
+This task persists every Inspector tool invocation as a structured audit record, exposes per-server and per-tool admin views, and emits aggregated usage metrics that downstream features (search ranking in Task 036, comparison in Task 040) can consume.
+
+The log is **append-only**, **PII-scrubbed**, and **retention-bounded** in line with the project's existing data governance baseline.
+
+## Dependencies
+
+- **033** — MCP Inspector Integration (the invocation surface)
+- **016** — Persistence baseline (Cosmos DB containers, soft-delete patterns)
+- **020** — Security Trimming (caller identity)
+- **028** — Analytics Data Collection (rollup pipeline)
+- **019** — App Insights telemetry
+
+## Implementation Details
+
+### 1. Audit Record Schema
+
+Add a Cosmos container `mcp-invocations` (partition key `/apiId`).
+
+```typescript
+interface McpInvocationRecord {
+  id: string;                // uuid
+  apiId: string;
+  apiName: string;
+  versionName: string | null;
+  toolName: string;
+  invokedAt: string;         // ISO timestamp
+  invokedBy: {
+    userOid: string;         // Entra object ID
+    tenantId: string;
+    roles: string[];
+  };
+  arguments: {
+    keys: string[];          // top-level argument names only
+    hash: string;            // sha256 of canonicalised JSON
+    sizeBytes: number;
+    redactedSnippet: string | null;  // first 200 chars, PII-scrubbed
+  };
+  result: {
+    isError: boolean;
+    durationMs: number;
+    contentItemCount: number;
+    contentSizeBytes: number;
+    errorCode: string | null;
+  };
+  source: 'inspector' | 'playground' | 'agent';
+  schemaVersion: 1;
+  ttl: number;               // Cosmos TTL — default 90 days
+}
+```
+
+**What we deliberately do _not_ store**: full argument values, full result text, server URLs (already in catalog), bearer tokens. The `hash` enables de-duplication and "this same call has been made before" lookups without retaining payloads.
+
+### 2. PII Scrubbing
+
+`redactedSnippet` runs the existing PII redactor (`docs/architecture/pii-handling.md`) over a JSON-stringified argument set, truncated to 200 chars. Document this in `pii-handling.md` as a new emission point.
+
+### 3. Persistence Hook
+
+Modify `routers/mcp_inspector.py:invoke_mcp_tool` to write the audit record after the upstream call returns (success or failure). Writes are best-effort — a Cosmos failure logs a warning but does not fail the user-facing response (same posture as Redis cache failures).
+
+The write happens via a new `McpInvocationRepository` in `services/` mirroring the existing repository pattern.
+
+### 4. Admin & Owner Views
+
+```
+app/admin/mcp-invocations/                         # admin global view
+app/catalog/[apiId]/components/McpInvocationsTab.tsx  # per-API owner view
+```
+
+**Admin global view** (`Portal.Admin` only):
+
+- Filterable table: `apiId`, `userOid`, `toolName`, time range, error-only.
+- Columns: timestamp, server, tool, user, duration, status (OK / Error), arguments hash.
+- CSV export.
+
+**Per-API tab** (visible to `Portal.Maintainer` and `Portal.Admin` for that API):
+
+- Last 30 days of invocations on this server.
+- Top tools by call count + error rate.
+- Sparkline of daily volume.
+- "Most active users" (anonymised counts unless caller is admin).
+
+### 5. BFF Endpoints
+
+```
+src/bff/apic_vibe_portal_bff/routers/mcp_invocations.py
+```
+
+| Method | Path | Roles | Description |
+|--------|------|-------|-------------|
+| `GET`  | `/api/mcp/invocations`              | `Portal.Admin`                    | Global list with filters |
+| `GET`  | `/api/mcp/{apiId}/invocations`      | `Portal.Maintainer`, `Portal.Admin` | Per-API list (security trimmed) |
+| `GET`  | `/api/mcp/{apiId}/invocations/stats`| `Portal.Maintainer`, `Portal.Admin` | Aggregates: counts, error rate, top tools, daily series |
+
+All endpoints support `from`, `to`, `toolName`, `userOid`, `errorOnly` query parameters. Results are paginated (`continuationToken`).
+
+### 6. Analytics Rollup
+
+Extend the analytics worker (Task 028) to compute daily aggregates per `apiId`/`toolName`:
+
+- `mcp_tool_invocations_daily` Cosmos container with `(apiId, toolName, date)` keys.
+- Counts: total, errors, p50/p95 duration, unique users.
+- Used by Task 040 (comparison) and Task 036 (search ranking signal).
+
+### 7. Telemetry
+
+Emit two App Insights custom events:
+
+- `mcp.tool.invoked` — minimal: `apiId`, `toolName`, `durationMs`, `isError`. Fires on every call.
+- `mcp.tool.error` — fires only on error with `errorCode` and `apiId`.
+
+### 8. Privacy & Compliance
+
+- The audit log is in-scope for the GDPR erasure flow defined in the data retention policy: erasing a user must delete or anonymise records matching their `userOid`.
+- TTL of 90 days is the default; an admin setting in `runtime-config` allows extension to 365 days for highly-regulated tenants.
+- Document the new log in `docs/architecture/pii-handling.md` and `docs/architecture/data-retention-policy.md`.
+
+## Testing & Acceptance Criteria
+
+- [ ] Inspector `tools/call` writes an `McpInvocationRecord` on success and on error.
+- [ ] Cosmos write failures do not propagate to the caller (best-effort).
+- [ ] Argument hash is deterministic across equivalent payloads (key-order independent).
+- [ ] `redactedSnippet` does not exceed 200 chars and PII patterns (email, phone, GUID-like tokens) are masked.
+- [ ] Records have a TTL field set to the configured retention.
+- [ ] Admin endpoint returns paginated results with all documented filters working.
+- [ ] Per-API endpoint returns 403 for users without Maintainer/Admin on that API (security trimmed).
+- [ ] Stats endpoint returns counts, error rate, top tools, daily series for the configured window.
+- [ ] Admin invocations page renders, filters, and exports CSV.
+- [ ] Per-API tab renders top tools, error rate, sparkline.
+- [ ] Daily rollup container is populated by the analytics worker.
+- [ ] App Insights events `mcp.tool.invoked` and `mcp.tool.error` fire with correct dimensions.
+- [ ] GDPR erasure of a user wipes/anonymises their `userOid` from `mcp-invocations`.
+
+## Implementation Notes
+
+<!--
+  This section is a living record updated by the implementing agent.
+  Update status, log decisions, and record validation results as work progresses.
+  When complete, change the Status at the top of this document to ✅ Complete.
+-->
+
+### Status History
+
+| Date | Status         | Author | Notes        |
+| ---- | -------------- | ------ | ------------ |
+| —    | 🔲 Not Started | —      | Task created |
+
+### Technical Decisions
+
+_To be recorded by the implementing agent._
+
+### Deviations from Plan
+
+_To be recorded by the implementing agent._
+
+### Validation Results
+
+_To be recorded by the implementing agent._
+
+## Coding Agent Prompt
+
+```text
+**Task**: Implement plan step 039 — MCP Invocation Audit Log.
+
+Read the full task specification at `docs/project/plan/039-mcp-invocation-audit-log.md`.
+
+Reference `docs/project/plan/033-mcp-inspector-integration.md` for the invocation entry point, `docs/project/plan/016-persistence-data-governance-baseline.md` for the repository pattern and TTL handling, `docs/project/plan/020-security-trimming.md` for caller identity, and `docs/architecture/pii-handling.md` for the redaction utility.
+
+Add a Cosmos container `mcp-invocations` with the schema in §1. Hook the inspector's `invoke_mcp_tool` to write a redacted, hashed audit record on every call (best-effort — don't fail user requests on write errors). Build admin and per-API listing/stats endpoints with RBAC + security trimming. Add the admin invocations page and the per-API invocations tab. Extend the analytics worker to roll up daily aggregates. Emit `mcp.tool.invoked` and `mcp.tool.error` App Insights events. Wire the new container into the GDPR erasure flow.
+
+Do NOT persist full argument or result content — only key names, hash, size, redacted snippet, and result metadata.
+
+Write unit tests covering hashing determinism, redaction, RBAC, write-failure tolerance, and the rollup math. Add an E2E test that invokes a tool and verifies the audit row.
+
+**Living Document Update**: After completing implementation, update this plan document:
+1. Change the status banner at the top to `> **✅ Status: Complete**`
+2. Add a row to the Status History table with the completion date and a summary
+3. Record any technical decisions made under "Technical Decisions"
+4. Note any deviations from the plan under "Deviations from Plan"
+5. Record test/validation results under "Validation Results"
+```

--- a/docs/project/plan/040-mcp-server-comparison.md
+++ b/docs/project/plan/040-mcp-server-comparison.md
@@ -1,0 +1,173 @@
+# 040 - MCP Server Comparison
+
+> **🔲 Status: Not Started**
+>
+> _This is a living document. Status and implementation notes are updated as work progresses._
+
+## References
+
+- [Architecture Document](../apic_architecture.md) — AI-powered features for API understanding
+- [Product Charter](../apic_product_charter.md) — Phase 2: Governance + Compare
+- [024 — API Comparison Feature](024-api-comparison-feature.md) — base compare framework
+- [036 — MCP Capability Indexing](036-mcp-capability-indexing.md) — capability snapshots
+- [037 — MCP Governance Rules](037-mcp-governance-rules.md) — risk profile
+- [038 — Capability Drift Detection](038-mcp-capability-drift-detection.md) — recency / churn signals
+- [039 — Invocation Audit Log](039-mcp-invocation-audit-log.md) — usage signals
+
+## Overview
+
+The existing comparison feature (Task 024) compares APIs on metadata, versions, endpoints, governance, deployments, and specifications. None of those aspects are particularly useful for choosing between two MCP servers. The questions a developer actually asks are:
+
+- "Which one has the tool I need?"
+- "Whose tool schemas are stricter?"
+- "Which one is more battle-tested?"
+- "Which one has fewer destructive tools / better risk profile?"
+- "Which one changes more often?"
+
+This task adds an MCP-specific comparison aspect that surfaces these signals using only data already collected in Tasks 036–039 (snapshots, governance, drift, invocation rollups). It plugs into the existing `/compare` page so users get the right comparison automatically when all selected APIs are `kind=mcp`.
+
+## Dependencies
+
+- **024** — API Comparison Feature (extension point)
+- **036** — MCP Capability Indexing
+- **037** — MCP Governance Rules
+- **038** — MCP Capability Drift Detection
+- **039** — MCP Invocation Audit Log
+
+## Implementation Details
+
+### 1. New Compare Aspects
+
+Extend the `CompareAspect` union in `src/shared/src/models/compare.ts`:
+
+```typescript
+type CompareAspect =
+  | 'metadata' | 'versions' | 'endpoints'
+  | 'governance' | 'deployments' | 'specifications'
+  // new MCP-specific aspects
+  | 'mcp.toolSurface'      // tool overlap matrix + counts
+  | 'mcp.schemaQuality'    // per-server schema strictness scores
+  | 'mcp.riskProfile'      // destructive/write tool counts, security flags
+  | 'mcp.churn'            // recent drift summary (last 90d)
+  | 'mcp.usage';           // invocation volume, error rate, popularity
+```
+
+When all selected APIs are `kind=mcp`, the default aspect set switches from the generic six to the five MCP aspects above (plus `metadata`).
+
+### 2. Tool Overlap Matrix
+
+The marquee feature: an N × M grid where rows are unique tool names across all selected servers and columns are servers, with ✓ in cells where the server provides that tool. Includes a "compatibility" column showing schema parity (identical / compatible-superset / divergent / incompatible) when ≥ 2 servers expose the same tool name.
+
+```typescript
+interface ToolOverlapMatrix {
+  toolNames: string[];
+  servers: { apiId: string; apiName: string }[];
+  cells: ToolOverlapCell[][];   // [toolIndex][serverIndex]
+}
+
+interface ToolOverlapCell {
+  present: boolean;
+  schemaCompatibility?: 'identical' | 'superset' | 'divergent' | 'incompatible';
+  toolFingerprint?: string;     // hash of normalised input schema
+}
+```
+
+Schema-compatibility classification is a deterministic helper that compares two tools' input schemas and reports the result. Live in `src/shared/src/mcp/tool-compatibility.ts`.
+
+### 3. Per-Server Aspect Computations
+
+```
+src/bff/apic_vibe_portal_bff/services/mcp_compare_service.py
+```
+
+For each selected MCP API the service produces:
+
+- **toolSurface**: total tools, unique tools (not in any other selected server), shared tools, tool overlap matrix.
+- **schemaQuality**: % tools with descriptions ≥ 20 chars, % tools with `required` array, % parameters with descriptions, % schemas with `additionalProperties: false`. Sourced from the same data Task 037 uses, but computed independently (don't reuse rule failures — that conflates "rule failed" with "metric").
+- **riskProfile**: destructive tool count, write tool count, has-shell-passthrough flag, auth-documented flag. From Task 037's `getMcpRiskProfile`.
+- **churn**: number of versions in the last 90 days; latest `changeKind`; count of breaking changes in that window. From Task 038.
+- **usage**: 30-day invocation count, error rate, top 3 tools by volume, unique caller count. From Task 039 daily rollups. Returns `null` for servers with no recorded invocations.
+
+### 4. AI Analysis Prompt Extensions
+
+Update the comparison agent prompt to handle MCP servers: "When all compared APIs are MCP servers, focus the narrative on (a) tool coverage gaps, (b) schema strictness trade-offs, (c) risk posture, and (d) which server is the better default for typical developer use cases."
+
+### 5. Frontend — MCP Compare View
+
+`app/compare/components/`:
+
+- `McpToolOverlapTable.tsx` — renders the overlap matrix with tooltips for cell details. Sticky first column (tool name).
+- `McpSchemaQualityBars.tsx` — horizontal bar chart, one row per metric per server.
+- `McpRiskProfileGrid.tsx` — small-multiples chip grid (one card per server).
+- `McpChurnTimeline.tsx` — sparkline of versions + breaking change markers, per server.
+- `McpUsageSummary.tsx` — three-column small-multiples (call count, error rate, top tools).
+
+`CompareTable.tsx` is updated to recognise the MCP aspect set and route those rows to the new components.
+
+### 6. Compatibility Filter
+
+When the user is comparing servers, surface a small "filter" at the top: "Show only tools available in at least N servers." This makes the matrix readable when comparing 4 servers with 50+ tools each.
+
+### 7. Backwards Compatibility
+
+Mixed selections (e.g. one REST + two MCP) fall back to the generic comparison — the new MCP aspects are not rendered. The MCP aspects are gated on `selectedApis.every(a => a.kind === 'mcp')`.
+
+## Testing & Acceptance Criteria
+
+- [ ] Tool overlap matrix correctly identifies present/absent for fixture servers.
+- [ ] `schemaCompatibility` classification matches the spec for each fixture pair (identical / superset / divergent / incompatible).
+- [ ] All five MCP aspects render when all selected APIs are MCP.
+- [ ] Mixed REST + MCP selection falls back to the generic six aspects.
+- [ ] `mcp.usage` returns `null` gracefully when no invocations have been recorded.
+- [ ] AI analysis prompt produces a narrative that mentions tool coverage and risk posture (smoke test against a known fixture).
+- [ ] `CompareSelector` allows up to 4 MCP servers (existing limit honored).
+- [ ] Tool overlap matrix tooltips show schema fingerprint and per-cell compatibility.
+- [ ] "Show only tools in ≥ N servers" filter narrows the matrix.
+- [ ] E2E: User compares two MCP servers, sees the matrix, and the matrix highlights a unique tool on one server.
+
+## Implementation Notes
+
+<!--
+  This section is a living record updated by the implementing agent.
+  Update status, log decisions, and record validation results as work progresses.
+  When complete, change the Status at the top of this document to ✅ Complete.
+-->
+
+### Status History
+
+| Date | Status         | Author | Notes        |
+| ---- | -------------- | ------ | ------------ |
+| —    | 🔲 Not Started | —      | Task created |
+
+### Technical Decisions
+
+_To be recorded by the implementing agent._
+
+### Deviations from Plan
+
+_To be recorded by the implementing agent._
+
+### Validation Results
+
+_To be recorded by the implementing agent._
+
+## Coding Agent Prompt
+
+```text
+**Task**: Implement plan step 040 — MCP Server Comparison.
+
+Read the full task specification at `docs/project/plan/040-mcp-server-comparison.md`.
+
+Reference `docs/project/plan/024-api-comparison-feature.md` for the comparison framework, `docs/project/plan/036-mcp-capability-indexing.md` for snapshot data, `docs/project/plan/037-mcp-governance-rules.md` for the risk profile tool, `docs/project/plan/038-mcp-capability-drift-detection.md` for churn signals, and `docs/project/plan/039-mcp-invocation-audit-log.md` for usage rollups.
+
+Extend the compare aspect union with five MCP aspects (toolSurface, schemaQuality, riskProfile, churn, usage). Build a deterministic tool-compatibility helper. Implement an mcp_compare_service that aggregates each aspect from existing data sources without reaching live MCP servers. Add the AI prompt extension. Build new frontend components for the tool overlap matrix, schema quality bars, risk profile grid, churn timeline, and usage summary. Gate MCP aspects on every selected API being kind=mcp; fall back to generic compare otherwise.
+
+Write unit tests for the compatibility classifier, every aspect computation, and the gating logic. Add an E2E test that compares two MCP fixtures and validates the matrix.
+
+**Living Document Update**: After completing implementation, update this plan document:
+1. Change the status banner at the top to `> **✅ Status: Complete**`
+2. Add a row to the Status History table with the completion date and a summary
+3. Record any technical decisions made under "Technical Decisions"
+4. Note any deviations from the plan under "Deviations from Plan"
+5. Record test/validation results under "Validation Results"
+```

--- a/docs/project/plan/041-mcp-playground-and-sessions.md
+++ b/docs/project/plan/041-mcp-playground-and-sessions.md
@@ -1,0 +1,209 @@
+# 041 - MCP Playground & Saved Sessions
+
+> **🔲 Status: Not Started**
+>
+> _This is a living document. Status and implementation notes are updated as work progresses._
+
+## References
+
+- [Architecture Document](../apic_architecture.md) — Persistence, BFF orchestration
+- [Product Charter](../apic_product_charter.md) — Enable AI-assisted workflows
+- [033 — MCP Inspector Integration](033-mcp-inspector-integration.md) — single-call inspector
+- [039 — MCP Invocation Audit Log](039-mcp-invocation-audit-log.md) — invocation persistence
+- [020 — Security Trimming](020-security-trimming.md)
+
+## Overview
+
+The current MCP Inspector is a one-shot tool: pick a tool, fill the form, see the result. Real-world MCP exploration is **multi-step** — call `list_files`, feed an output into `read_file`, then chain into `summarise`. The Inspector cannot represent this, and there is no way to save a verified sequence as documentation, a regression scenario, or a shareable example.
+
+This task introduces a **Playground** mode on the API detail page that supports ordered tool sequences with cell-style outputs, and a **Saved Sessions** facility that lets users persist, name, share (within RBAC), and replay a sequence. Saved sessions also serve as durable, executable documentation: an API owner can publish "How to use this server" as a session that any consumer can replay.
+
+## Dependencies
+
+- **033** — MCP Inspector Integration
+- **016** — Persistence baseline
+- **020** — Security Trimming
+- **039** — MCP Invocation Audit Log (writes still happen via the same hook)
+
+## Implementation Details
+
+### 1. Session Schema
+
+Add a Cosmos container `mcp-sessions` (partition key `/apiId`).
+
+```typescript
+interface McpSession {
+  id: string;                  // uuid
+  apiId: string;
+  apiName: string;
+  versionName: string | null;
+  ownerOid: string;            // creator
+  name: string;
+  description: string | null;
+  visibility: 'private' | 'shared-org' | 'published';
+  steps: McpSessionStep[];
+  variables: Record<string, McpVariableSpec>;  // user-declared inputs
+  createdAt: string;
+  updatedAt: string;
+  schemaVersion: 1;
+}
+
+interface McpSessionStep {
+  stepId: string;              // ulid
+  toolName: string;
+  argumentsTemplate: string;   // JSON-with-$refs (see §3)
+  notes: string | null;
+  expectError: boolean;
+}
+
+interface McpVariableSpec {
+  name: string;
+  type: 'string' | 'number' | 'boolean';
+  description: string | null;
+  defaultValue: string | null;
+}
+```
+
+Visibility tiers:
+
+- **private** — visible only to `ownerOid`.
+- **shared-org** — visible to any caller with read access to the API (security-trimmed).
+- **published** — visible to any catalog reader; flagged in UI as official documentation. Only the API's `Portal.Maintainer` or `Portal.Admin` can publish.
+
+### 2. Playground UI
+
+```
+app/catalog/[apiId]/components/McpPlaygroundTab.tsx
+app/catalog/[apiId]/components/McpStepCell.tsx
+app/catalog/[apiId]/components/McpSessionToolbar.tsx
+app/catalog/[apiId]/components/McpVariableEditor.tsx
+```
+
+Layout: a notebook-style column of cells. Each cell:
+
+- Tool selector (auto-completed against the capability list).
+- Argument editor — same schema-driven form as the Inspector, plus the ability to insert `$ref` placeholders.
+- "Run cell" button.
+- Output area: result content + status chip + duration (reuses the Inspector's `InvokeResultPanel`).
+- "Insert variable" / "Insert step output reference" controls.
+
+A toolbar above the cells offers: Run all, Stop, Reset outputs, Save session, Open saved session, Share, Publish.
+
+### 3. Step Output References
+
+`argumentsTemplate` is a JSON object that may contain string-literal `$ref` placeholders:
+
+- `"$step.<stepId>.content[0].text"` — pulls a value from a previous step's result.
+- `"$var.<name>"` — pulls a user-declared variable.
+
+A small reference resolver in `src/shared/src/mcp/session-runtime.ts` walks the template at runtime, evaluates each `$ref` against the live execution context, type-coerces according to the tool's input schema, and produces the final arguments object. Missing refs surface as a typed runtime error (`UNRESOLVED_REF`) before any upstream call.
+
+### 4. BFF Endpoints
+
+```
+src/bff/apic_vibe_portal_bff/routers/mcp_sessions.py
+```
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `POST`   | `/api/mcp/{apiId}/sessions`              | Create a session                     |
+| `GET`    | `/api/mcp/{apiId}/sessions`              | List visible sessions for this API   |
+| `GET`    | `/api/mcp/{apiId}/sessions/{sessionId}`  | Fetch a session                      |
+| `PUT`    | `/api/mcp/{apiId}/sessions/{sessionId}`  | Update (owner or maintainer only)    |
+| `DELETE` | `/api/mcp/{apiId}/sessions/{sessionId}`  | Soft delete (owner or admin only)    |
+| `POST`   | `/api/mcp/{apiId}/sessions/{sessionId}/publish` | Maintainer/Admin only         |
+| `POST`   | `/api/mcp/{apiId}/sessions/{sessionId}/run`     | Server-side run (see §5)        |
+
+All endpoints enforce RBAC + security trimming on `apiId` and visibility-tier checks per session.
+
+### 5. Session Runs — Two Modes
+
+**Client-side** (default): The Playground UI runs each step by calling the existing `POST /api/mcp/{apiId}/invoke` endpoint per cell. Each call still writes an audit record (Task 039) with `source: 'playground'`.
+
+**Server-side** (`/run`): Runs the entire session top-to-bottom on the BFF and returns an array of step results. Used for:
+
+- Replay-from-link sharing (no client logic required).
+- Regression checks invoked from the admin UI.
+- Future scheduled "session-as-test" jobs.
+
+Server-side runs are subject to a 60s wall-clock cap and a per-session step cap of 25.
+
+### 6. Sharing & Permalinks
+
+Each saved session has a permalink: `/catalog/{apiId}?tab=playground&session={sessionId}`. Loading the page with this URL opens the Playground tab pre-populated with the session.
+
+Variables prompted from the user before "Run all" begins; defaults pre-fill the input.
+
+### 7. Published Sessions on the API Detail Page
+
+A new collapsible section on the Overview tab of MCP API detail pages: "Quickstart sessions" — lists `published` sessions for the API with a one-click "Open in playground" link. This makes published sessions act as executable documentation.
+
+### 8. Variable Redaction
+
+Variables marked `secret: true` are masked in the UI display, redacted from the audit log's `redactedSnippet`, and excluded from the published session export.
+
+## Testing & Acceptance Criteria
+
+- [ ] Playground tab renders for MCP APIs only.
+- [ ] User can add, reorder, and delete cells.
+- [ ] Schema-driven form per cell mirrors Inspector behaviour.
+- [ ] `$step.<id>.…` references resolve at run-time and produce correct typed arguments.
+- [ ] `$var.<name>` references prompt the user before "Run all".
+- [ ] `UNRESOLVED_REF` surfaces a typed error without invoking the upstream tool.
+- [ ] Each Playground cell run writes an audit record with `source: 'playground'`.
+- [ ] Save session → list session → reload session round-trips faithfully.
+- [ ] Visibility-tier RBAC: private sessions invisible to non-owner; shared-org honors security trimming; published gated on Maintainer/Admin.
+- [ ] Permalink to a session opens Playground pre-populated.
+- [ ] Server-side `/run` returns all step results within wall-clock + step-count caps.
+- [ ] Secret variables are masked in UI and audit `redactedSnippet`.
+- [ ] Published sessions appear on the Overview tab Quickstart section.
+- [ ] E2E: Create a 3-step session that chains list → read → summarise; save; reopen; run all; verify the chained outputs.
+
+## Implementation Notes
+
+<!--
+  This section is a living record updated by the implementing agent.
+  Update status, log decisions, and record validation results as work progresses.
+  When complete, change the Status at the top of this document to ✅ Complete.
+-->
+
+### Status History
+
+| Date | Status         | Author | Notes        |
+| ---- | -------------- | ------ | ------------ |
+| —    | 🔲 Not Started | —      | Task created |
+
+### Technical Decisions
+
+_To be recorded by the implementing agent._
+
+### Deviations from Plan
+
+_To be recorded by the implementing agent._
+
+### Validation Results
+
+_To be recorded by the implementing agent._
+
+## Coding Agent Prompt
+
+```text
+**Task**: Implement plan step 041 — MCP Playground & Saved Sessions.
+
+Read the full task specification at `docs/project/plan/041-mcp-playground-and-sessions.md`.
+
+Reference `docs/project/plan/033-mcp-inspector-integration.md` for the existing tool-call surface and form patterns; `docs/project/plan/039-mcp-invocation-audit-log.md` for the audit hook (Playground runs must still write audit records with source='playground'); `docs/project/plan/020-security-trimming.md` for visibility-tier RBAC; and `docs/project/plan/016-persistence-data-governance-baseline.md` for the Cosmos repository pattern.
+
+Build a notebook-style Playground tab on the MCP API detail page with cell-based ordered tool runs, schema-driven argument editing, and a `$step` / `$var` reference resolver implemented in src/shared. Persist sessions in a new `mcp-sessions` Cosmos container with three visibility tiers (private / shared-org / published) and RBAC-gated transitions. Add CRUD + publish + server-side run endpoints. Add a permalink-loadable share link and a Quickstart sessions panel on the Overview tab for published sessions.
+
+Run modes: client-side (default, hits existing invoke endpoint per cell) and server-side `/run` (capped at 25 steps and 60s). Both must write audit records.
+
+Write unit tests for the reference resolver, RBAC transitions, and run mode caps; an integration test for a 3-step chain; and an E2E test for save → reload → run-all.
+
+**Living Document Update**: After completing implementation, update this plan document:
+1. Change the status banner at the top to `> **✅ Status: Complete**`
+2. Add a row to the Status History table with the completion date and a summary
+3. Record any technical decisions made under "Technical Decisions"
+4. Note any deviations from the plan under "Deviations from Plan"
+5. Record test/validation results under "Validation Results"
+```

--- a/docs/project/plan/042-mcp-discovery-endpoint.md
+++ b/docs/project/plan/042-mcp-discovery-endpoint.md
@@ -1,0 +1,210 @@
+# 042 - MCP Discovery Endpoint for AI Agents
+
+> **🔲 Status: Not Started**
+>
+> _This is a living document. Status and implementation notes are updated as work progresses._
+
+## References
+
+- [Architecture Document](../apic_architecture.md) — Security, BFF, Persistence
+- [Product Charter](../apic_product_charter.md) — Improve API discovery; AI-assisted workflows
+- [008 — Entra ID Authentication](008-entra-id-authentication.md)
+- [020 — Security Trimming](020-security-trimming.md)
+- [036 — MCP Capability Indexing](036-mcp-capability-indexing.md)
+- [037 — MCP Governance Rules](037-mcp-governance-rules.md)
+
+## Overview
+
+Today the portal is a **human** interface to MCP servers — a UI for browsing, inspecting, comparing. The other half of the registry value is exposing the same catalog to **agents** so they can discover MCP servers programmatically, with the same identity-aware filtering (RBAC + security trimming) that the human UI enforces.
+
+This task adds an authenticated, machine-readable discovery API that emits an MCP-registry manifest tailored to the calling identity. Tools like Claude Desktop, VS Code Copilot, Cursor, and custom Foundry agents can fetch this manifest, parse it, and configure themselves to talk to the MCP servers the caller is allowed to use — without the caller hand-curating an `mcp.json` per machine.
+
+This is the feature that turns the portal from "APIC with a nicer UI" into "the registry an enterprise points its agents at."
+
+## Dependencies
+
+- **008** — Entra ID Authentication (caller identity)
+- **020** — Security Trimming (per-API access)
+- **036** — MCP Capability Indexing (capability data the manifest summarises)
+- **037** — MCP Governance Rules (risk badges in the manifest)
+- **019** — App Insights (usage telemetry)
+
+## Implementation Details
+
+### 1. Manifest Format
+
+A versioned, JSON-only manifest at `GET /api/mcp/registry/manifest`.
+
+```typescript
+interface McpRegistryManifest {
+  schemaVersion: 1;
+  generatedAt: string;
+  registry: {
+    name: string;          // configured portal display name
+    portalUrl: string;     // base URL of the portal
+  };
+  caller: {
+    oid: string;
+    tenantId: string;
+    roles: string[];
+  };
+  servers: McpRegistryServerEntry[];
+}
+
+interface McpRegistryServerEntry {
+  apiId: string;
+  apiName: string;
+  versionName: string;
+  description: string | null;
+  serverUrl: string;
+  transport: 'streamable-http' | 'sse';
+  auth: McpAuthDescriptor;            // see §3
+  capabilities: {
+    toolCount: number;
+    promptCount: number;
+    resourceCount: number;
+    toolNames: string[];              // names only — not full schemas
+  };
+  governance: {
+    score: number | null;             // 0–100
+    hasDestructiveTools: boolean;
+    riskLevel: 'low' | 'medium' | 'high';
+  };
+  links: {
+    detail: string;                   // portal API detail URL
+    inspector: string;                // deep link to inspector tab
+    capabilities: string;             // /api/mcp/{apiId}/capabilities
+  };
+}
+```
+
+The manifest is **already filtered** to APIs the caller can see (RBAC + security trimming). Filters apply at generation time, not at the consumer.
+
+### 2. Endpoint Surface
+
+```
+src/bff/apic_vibe_portal_bff/routers/mcp_registry.py
+src/bff/apic_vibe_portal_bff/services/mcp_registry_service.py
+```
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET`  | `/api/mcp/registry/manifest`                            | Full manifest, filtered to caller |
+| `GET`  | `/api/mcp/registry/manifest?tags=&riskLevel=&hasTool=`  | Filtered manifest                  |
+| `GET`  | `/api/mcp/registry/manifest/vscode`                     | VS Code `mcp.json` profile         |
+| `GET`  | `/api/mcp/registry/manifest/claude`                     | Claude Desktop `claude_desktop_config.json` profile |
+| `GET`  | `/api/mcp/registry/manifest/openapi`                    | OpenAPI 3 description of this surface |
+| `GET`  | `/.well-known/mcp-registry`                             | Service discovery (returns capability + auth metadata) |
+
+The two profile endpoints return the same data shaped to a specific consumer's config schema, saving operators from writing transformers.
+
+### 3. Auth Descriptor
+
+Each server entry includes a structured `auth` block describing how the consumer must authenticate to the upstream MCP server:
+
+```typescript
+type McpAuthDescriptor =
+  | { type: 'none' }
+  | { type: 'entra'; tenantId: string; clientId: string; scopes: string[] }
+  | { type: 'oauth2'; authorizationUrl: string; tokenUrl: string; scopes: string[] }
+  | { type: 'apikey'; header: string; instructionsUrl: string }
+  | { type: 'token-broker'; brokerUrl: string };  // reserved for future Task
+
+The descriptor is sourced from the API Center metadata for the deployment. APIs without a recognisable auth descriptor default to `{ type: 'none' }` and a governance warning is emitted.
+
+### 4. Authentication & Authorisation
+
+- All endpoints require Entra ID (same `acquireToken` flow as the rest of the portal). No anonymous access.
+- A new role `Portal.Agent` is introduced — a least-privilege role specifically for headless agent identities (service principals, managed identities). It has read-only access to the registry endpoints and **no** access to admin pages or invocation surfaces.
+- Existing `Portal.User` / `Portal.Maintainer` / `Portal.Admin` continue to work and see the same filtered manifest as their UI experience.
+- Calls are rate-limited per (caller oid, endpoint) — default 60/min, configurable.
+
+### 5. Caching
+
+- Manifest generation is cached in Redis per-caller for 60 seconds (`mcp:registry:manifest:{oid}`). Filter parameters are included in the cache key.
+- Cache invalidates when: the indexer (Task 036) writes a new snapshot, or governance rules are recomputed for an API in the manifest. Invalidation is broadcast via a Redis pub/sub channel `mcp.registry.invalidate`.
+
+### 6. CLI / Helpers
+
+- `scripts/print-mcp-manifest.py` — pretty-prints the manifest for a given Entra token. Useful for ops debugging.
+- `scripts/install-mcp-from-portal.sh` — fetches the VS Code profile and merges it into the developer's local `mcp.json`. (Read-only, prompts before overwrite.)
+
+### 7. Security Considerations
+
+- **No bearer tokens in the manifest.** The manifest describes _how_ to authenticate, never carries a token to a downstream server.
+- **No tool schemas in the manifest.** Schemas can leak business logic and are large; consumers fetch them via the existing `/api/mcp/{apiId}/capabilities` endpoint as needed.
+- **No invocation surface.** This endpoint is read-only discovery; tool calls still go through the existing inspector endpoints with their own RBAC.
+- **CORS**: Manifest endpoints reject browser-origin calls by default. They are designed for server-to-server / IDE consumption and should not be exposed to public web clients.
+
+### 8. Telemetry
+
+Emit App Insights events:
+
+- `mcp.registry.manifest_fetched` — `oid`, `userAgent`, `serverCount`, `filtersApplied`.
+- `mcp.registry.profile_fetched` — `oid`, `profile` (`vscode` | `claude`).
+
+These let admins see which agents are actually using the registry.
+
+## Testing & Acceptance Criteria
+
+- [ ] Manifest endpoint requires authentication (401 without token).
+- [ ] Manifest contains only APIs the caller can see (regression test against fixture with mixed-access APIs).
+- [ ] Filter params (`tags`, `riskLevel`, `hasTool`) narrow results correctly.
+- [ ] VS Code profile output validates against the VS Code `mcp.json` schema.
+- [ ] Claude profile output is valid JSON loadable by Claude Desktop.
+- [ ] Auth descriptor is populated for every entry; APIs with unknown auth default to `{type: 'none'}` and emit a governance warning.
+- [ ] Manifest never contains tokens, full tool schemas, or invocation surfaces.
+- [ ] `Portal.Agent` role can read manifest; cannot read admin endpoints.
+- [ ] Rate limiter enforces the configured per-caller/per-endpoint limit.
+- [ ] Redis cache returns the same payload within TTL; indexer writes invalidate the cache.
+- [ ] `/.well-known/mcp-registry` returns service metadata (auth + endpoints) without requiring auth.
+- [ ] OpenAPI description endpoint returns a valid OpenAPI 3 doc for the registry surface.
+- [ ] `mcp.registry.manifest_fetched` event fires on every successful fetch with the documented dimensions.
+- [ ] E2E: A test client authenticates as `Portal.Agent`, fetches the manifest, and sees only the expected fixture servers.
+
+## Implementation Notes
+
+<!--
+  This section is a living record updated by the implementing agent.
+  Update status, log decisions, and record validation results as work progresses.
+  When complete, change the Status at the top of this document to ✅ Complete.
+-->
+
+### Status History
+
+| Date | Status         | Author | Notes        |
+| ---- | -------------- | ------ | ------------ |
+| —    | 🔲 Not Started | —      | Task created |
+
+### Technical Decisions
+
+_To be recorded by the implementing agent._
+
+### Deviations from Plan
+
+_To be recorded by the implementing agent._
+
+### Validation Results
+
+_To be recorded by the implementing agent._
+
+## Coding Agent Prompt
+
+```text
+**Task**: Implement plan step 042 — MCP Discovery Endpoint for AI Agents.
+
+Read the full task specification at `docs/project/plan/042-mcp-discovery-endpoint.md`.
+
+Reference `docs/project/plan/008-entra-id-authentication.md` for the auth flow, `docs/project/plan/020-security-trimming.md` for per-API filtering, `docs/project/plan/036-mcp-capability-indexing.md` for the capability data, and `docs/project/plan/037-mcp-governance-rules.md` for the risk profile that feeds the manifest.
+
+Build the manifest service and router with the schema in §1. Implement RBAC including a new `Portal.Agent` role. Add filter params (tags, riskLevel, hasTool), VS Code and Claude profile transformers, an OpenAPI surface, and a `/.well-known/mcp-registry` discovery endpoint. Cache per-caller in Redis with pub/sub-driven invalidation tied to indexer + governance writes. Emit telemetry. Reject browser CORS by default. Never include tokens or full tool schemas in the manifest.
+
+Write unit tests covering RBAC, security-trimmed filtering, profile transformations, cache invalidation, and rate limiting. Add an E2E test that exercises the manifest as `Portal.Agent`.
+
+**Living Document Update**: After completing implementation, update this plan document:
+1. Change the status banner at the top to `> **✅ Status: Complete**`
+2. Add a row to the Status History table with the completion date and a summary
+3. Record any technical decisions made under "Technical Decisions"
+4. Note any deviations from the plan under "Deviations from Plan"
+5. Record test/validation results under "Validation Results"
+```

--- a/docs/project/plan/043-mcp-self-service-publishing.md
+++ b/docs/project/plan/043-mcp-self-service-publishing.md
@@ -1,0 +1,239 @@
+# 043 - MCP Server Self-Service Publishing
+
+> **🔲 Status: Not Started**
+>
+> _This is a living document. Status and implementation notes are updated as work progresses._
+
+## References
+
+- [Architecture Document](../apic_architecture.md) — API Center, BFF, RBAC
+- [Product Charter](../apic_product_charter.md) — Improve API discovery; metadata completeness
+- [009 — API Center Data Layer](009-api-center-data-layer.md)
+- [023 — Governance Agent](023-governance-agent.md)
+- [036 — MCP Capability Indexing](036-mcp-capability-indexing.md)
+- [037 — MCP Governance Rules](037-mcp-governance-rules.md)
+- [034 — API Center Backup](034-api-center-backup.md) — entity export schema (informs registration payload)
+
+## Overview
+
+Today, registering a new MCP server in API Center is a Bicep / az-cli exercise — too friction-heavy for ad-hoc internal contributors. The result is a registry that grows write-only, where API owners ship servers but never get them into the catalog because the on-ramp is too steep.
+
+This task adds a **self-service publishing flow**: a guided UI through which a developer submits a candidate MCP server, runs an automated validation pipeline (governance + schema + auth checks), and on success creates the corresponding API Center entry with metadata pre-filled from the candidate manifest. A submission stays in a pending state until a `Portal.Maintainer` or `Portal.Admin` approves it.
+
+The validation pipeline reuses the rule set built in Task 037 — so the bar to enter the catalog is the same bar that governs what's already in it.
+
+## Dependencies
+
+- **009** — API Center Data Layer (write path)
+- **023** — Governance Agent (rule engine)
+- **036** — MCP Capability Indexing (definition parser, snapshot model)
+- **037** — MCP Governance Rules (validation rule set)
+- **020** — Security Trimming (RBAC)
+
+## Implementation Details
+
+### 1. Submission Schema
+
+Add a Cosmos container `mcp-submissions` (partition key `/submitterOid`).
+
+```typescript
+interface McpSubmission {
+  id: string;                     // uuid
+  submitterOid: string;
+  submitterEmail: string;
+  status: SubmissionStatus;
+  proposedApiId: string;          // slug, derived from name
+  proposedName: string;
+  description: string;
+  contacts: Contact[];
+  serverUrl: string;
+  transport: 'streamable-http' | 'sse';
+  authDescriptor: McpAuthDescriptor;
+  definitionPayload: unknown;     // raw JSON the submitter uploaded
+  validationReport: ValidationReport | null;
+  reviewerOid: string | null;
+  reviewNotes: string | null;
+  createdAt: string;
+  updatedAt: string;
+  schemaVersion: 1;
+}
+
+type SubmissionStatus =
+  | 'draft'             // submitter is still editing
+  | 'validating'        // pipeline running
+  | 'validation_failed' // critical rules failed
+  | 'awaiting_review'   // passed validation, queued for human review
+  | 'approved'          // registered into APIC
+  | 'rejected'
+  | 'withdrawn';
+```
+
+```typescript
+interface ValidationReport {
+  ranAt: string;
+  passed: boolean;
+  ruleResults: RuleResult[];     // reuses 023's RuleResult shape
+  parserWarnings: string[];      // from the definition parser
+  authPreflightResult: 'ok' | 'unreachable' | 'unauthenticated' | 'skipped';
+}
+```
+
+### 2. Validation Pipeline
+
+A single pure-ish service `McpSubmissionValidator` that runs the following checks against a submission:
+
+1. **Definition parses** via the Task 036 shared parser.
+2. **Capability counts** within configurable bounds (e.g. ≤ 200 tools).
+3. **Critical governance rules** from Task 037 pass: `mcp.tools.unique_names`, `mcp.tools.no_shell_passthrough`, `mcp.tools.destructive_verb_review`, plus all metadata.* rules.
+4. **Auth preflight** — best-effort. If the submitter provided an Entra-secured server URL and the BFF's managed identity has the relevant scopes, run an `initialize` call. If not, skip with `'skipped'` (this is the only place the BFF talks to the live MCP endpoint, and it's behind explicit configuration).
+5. **Slug uniqueness** in API Center.
+
+A submission is `validation_failed` if any critical rule fails. Warnings/info-severity rule failures are recorded but do not block.
+
+### 3. Submitter UI
+
+```
+app/submit-mcp/                                    # new top-level page
+├── page.tsx                                       # multi-step form
+├── components/SubmissionStep1Metadata.tsx
+├── components/SubmissionStep2Definition.tsx       # paste-or-upload
+├── components/SubmissionStep3Auth.tsx
+├── components/SubmissionStep4Review.tsx
+├── components/SubmissionValidationPanel.tsx
+└── components/MySubmissionsTable.tsx
+```
+
+- Wizard with metadata → definition upload → auth descriptor → review.
+- Auto-derives a slug from name; lets the user edit.
+- Step 4 runs the validator and renders the report inline. If validation fails, the user can edit and re-validate without losing state.
+- On success, the submission moves to `awaiting_review`.
+- A "My submissions" tab lists the user's submissions and their status.
+
+### 4. Reviewer UI
+
+```
+app/admin/mcp-submissions/
+├── page.tsx                                       # queue
+└── [submissionId]/page.tsx                        # detail + approve/reject
+```
+
+- Queue table filtered by status, with sort by submitted-at and validation result.
+- Detail page renders the full validation report (rule-by-rule), the proposed APIC entry preview, and approve/reject buttons.
+- Approving triggers the **registration step** (§5).
+- Rejection requires a reason that is emailed back to the submitter.
+
+### 5. Registration Step (Approval → APIC Write)
+
+The BFF writes the new API to API Center via the data-plane client:
+
+- Create API resource with metadata from the submission.
+- Create initial version `v1`.
+- Upload the definition payload as a Definition document with the appropriate content type.
+- Create deployment resource pointing to `serverUrl` with the configured environment.
+- Apply tags and contact metadata.
+
+If any APIC write fails, the submission is moved to a new state `registration_failed` and the partial APIC writes are rolled back where possible. A reviewer can retry.
+
+After successful registration, the indexer (Task 036) picks up the new API on its next run and the capability snapshot is captured automatically.
+
+### 6. BFF Endpoints
+
+```
+src/bff/apic_vibe_portal_bff/routers/mcp_submissions.py
+src/bff/apic_vibe_portal_bff/services/mcp_submission_service.py
+src/bff/apic_vibe_portal_bff/services/mcp_submission_validator.py
+src/bff/apic_vibe_portal_bff/services/mcp_apic_registrar.py
+```
+
+| Method | Path | Roles | Description |
+|--------|------|-------|-------------|
+| `POST`   | `/api/mcp/submissions`                        | any authenticated | Create draft |
+| `GET`    | `/api/mcp/submissions/mine`                   | any authenticated | List own submissions |
+| `GET`    | `/api/mcp/submissions/{id}`                   | submitter or reviewer | Fetch |
+| `PUT`    | `/api/mcp/submissions/{id}`                   | submitter (only while editable) | Update draft fields |
+| `POST`   | `/api/mcp/submissions/{id}/validate`          | submitter | Run validator |
+| `POST`   | `/api/mcp/submissions/{id}/withdraw`          | submitter | Withdraw |
+| `GET`    | `/api/mcp/submissions/queue`                  | Maintainer / Admin | Reviewer queue |
+| `POST`   | `/api/mcp/submissions/{id}/approve`           | Maintainer / Admin | Approve & register |
+| `POST`   | `/api/mcp/submissions/{id}/reject`            | Maintainer / Admin | Reject with reason |
+
+### 7. Notifications
+
+- Submitter: email on status transitions (`validation_failed`, `awaiting_review` confirmation, `approved`, `rejected`).
+- Reviewers: in-portal badge on `/admin/mcp-submissions` showing pending count; optional Teams/email digest (configurable, off by default).
+
+### 8. Observability
+
+- App Insights events: `mcp.submission.created`, `mcp.submission.validated`, `mcp.submission.approved`, `mcp.submission.rejected`, `mcp.submission.registration_failed`.
+- Submission audit log: status transitions tracked in a sub-collection so a reviewer can see who approved what and when.
+
+### 9. Documentation
+
+- New user-guide page `docs/user-guide/publishing-mcp-server.md` walking through the flow.
+- New developer doc `docs/development/mcp-submission-validator.md` describing the validator's rule set, rule severity gates, and how to extend them.
+
+## Testing & Acceptance Criteria
+
+- [ ] Authenticated user can create, edit, and withdraw a submission.
+- [ ] Wizard steps validate inputs and prevent invalid transitions.
+- [ ] Validator runs all checks in §2 and produces a structured report.
+- [ ] Critical-rule failures block transition to `awaiting_review`.
+- [ ] Warning/info failures are recorded but do not block.
+- [ ] Auth preflight degrades gracefully when the BFF cannot reach the upstream server (`'unreachable'`/`'skipped'` rather than a hard failure).
+- [ ] Reviewer queue lists submissions in correct state and respects RBAC.
+- [ ] Approve registers the API in APIC: API resource, version, definition, deployment, tags, contacts.
+- [ ] Failed registration moves submission to `registration_failed` and surfaces the underlying error in the reviewer UI.
+- [ ] Reject with reason transitions to `rejected` and notifies submitter (verified by email-fixture test).
+- [ ] Indexer picks up the newly registered API and creates a capability snapshot on its next scheduled run.
+- [ ] All `mcp.submission.*` App Insights events fire with the correct dimensions.
+- [ ] Slug collisions in APIC are detected before registration is attempted.
+- [ ] User can re-edit and re-validate a `validation_failed` submission without losing prior data.
+
+## Implementation Notes
+
+<!--
+  This section is a living record updated by the implementing agent.
+  Update status, log decisions, and record validation results as work progresses.
+  When complete, change the Status at the top of this document to ✅ Complete.
+-->
+
+### Status History
+
+| Date | Status         | Author | Notes        |
+| ---- | -------------- | ------ | ------------ |
+| —    | 🔲 Not Started | —      | Task created |
+
+### Technical Decisions
+
+_To be recorded by the implementing agent._
+
+### Deviations from Plan
+
+_To be recorded by the implementing agent._
+
+### Validation Results
+
+_To be recorded by the implementing agent._
+
+## Coding Agent Prompt
+
+```text
+**Task**: Implement plan step 043 — MCP Server Self-Service Publishing.
+
+Read the full task specification at `docs/project/plan/043-mcp-self-service-publishing.md`.
+
+Reference `docs/project/plan/009-api-center-data-layer.md` for the APIC write surface, `docs/project/plan/023-governance-agent.md` and `docs/project/plan/037-mcp-governance-rules.md` for the validator's rule set, `docs/project/plan/036-mcp-capability-indexing.md` for the definition parser and downstream indexing, and `docs/project/plan/020-security-trimming.md` for RBAC.
+
+Build a four-step submission wizard, a Cosmos-backed submission store with the state machine in §1, a validator service that exercises Task 037's critical rules plus parser + slug uniqueness + optional live auth preflight, a reviewer queue + detail page, and an APIC registrar that creates API + version + definition + deployment on approval (with rollback on failure). Wire submitter and reviewer notifications. Emit App Insights `mcp.submission.*` events for every state transition.
+
+The validator is the only place this feature is permitted to talk to a live MCP endpoint, and only behind explicit configuration. All other operations work from stored data.
+
+Write unit tests for the validator (each rule, both pass and fail), the state machine, RBAC, and registrar rollback. Add an integration test for create → validate → approve → register, asserting the resulting APIC entry. Add an E2E test for the submitter wizard.
+
+**Living Document Update**: After completing implementation, update this plan document:
+1. Change the status banner at the top to `> **✅ Status: Complete**`
+2. Add a row to the Status History table with the completion date and a summary
+3. Record any technical decisions made under "Technical Decisions"
+4. Note any deviations from the plan under "Deviations from Plan"
+5. Record test/validation results under "Validation Results"
+```

--- a/docs/project/plan/README.md
+++ b/docs/project/plan/README.md
@@ -109,6 +109,19 @@ Complete usage analytics, metadata scoring, performance optimization, and launch
 | [034](034-api-center-backup.md)         | Azure API Center Backup    | ✅     | 002, 005, 006, 008, 009, 016, 020 |
 | [035](035-api-center-backup-remediation.md) | API Center Backup Remediation | ✅ | 034                       |
 
+### MCP Registry Expansion
+
+| #                                              | Task                                     | Status | Key Dependencies                  |
+| ---------------------------------------------- | ---------------------------------------- | ------ | --------------------------------- |
+| [036](036-mcp-capability-indexing.md)          | MCP Capability Indexing                  | 🔲     | 009, 013, 016, 033                |
+| [037](037-mcp-governance-rules.md)             | MCP Governance & Best-Practices Rules    | 🔲     | 023, 025, 036                     |
+| [038](038-mcp-capability-drift-detection.md)   | MCP Capability Drift Detection           | 🔲     | 019, 036, 037                     |
+| [039](039-mcp-invocation-audit-log.md)         | MCP Invocation Audit Log                 | 🔲     | 016, 019, 020, 028, 033           |
+| [040](040-mcp-server-comparison.md)            | MCP Server Comparison                    | 🔲     | 024, 036, 037, 038, 039           |
+| [041](041-mcp-playground-and-sessions.md)      | MCP Playground & Saved Sessions          | 🔲     | 016, 020, 033, 039                |
+| [042](042-mcp-discovery-endpoint.md)           | MCP Discovery Endpoint for AI Agents     | 🔲     | 008, 019, 020, 036, 037           |
+| [043](043-mcp-self-service-publishing.md)      | MCP Server Self-Service Publishing       | 🔲     | 009, 020, 023, 036, 037           |
+
 ---
 
 ## Dependency Graph


### PR DESCRIPTION
This pull request adds two new project plan documents outlining upcoming work for MCP (Multi-capability Provider) APIs: capability indexing and governance rule enforcement. These documents specify requirements and implementation details for extending the platform’s search, indexing, and governance features to operate at the tool/prompt/resource level within MCP APIs.

The most important changes are:

**MCP Capability Indexing (docs/project/plan/036-mcp-capability-indexing.md):**

* Introduces a new pipeline to extract tools, prompts, and resources from MCP API definitions, snapshot them to Cosmos DB, and index them into a new AI Search index for fine-grained discovery.
* Specifies a shared parser (TypeScript + Python) to normalize and validate MCP definitions, with robust error handling and idempotency checks.
* Describes frontend and BFF changes: a new search endpoint for MCP capabilities, a "Tools" tab in the search UI, and tool-count chips in catalog cards.

**MCP Governance & Best-Practices Rules (docs/project/plan/037-mcp-governance-rules.md):**

* Details a set of new governance rules targeting MCP tools (e.g., description quality, schema strictness, security posture, naming hygiene), with remediation guidance for API owners.
* Outlines integration with the existing rule engine, dashboard UI enhancements (per-tool breakdowns, risk-profile cards), and new agent tools for risk profiling and rule failure queries.

These documents serve as living specifications for upcoming implementation work, including acceptance criteria and instructions for updating the plans upon completion.